### PR TITLE
Fix/nested fragments for require-id-when-available

### DIFF
--- a/packages/plugin/tests/__snapshots__/require-id-when-available.spec.ts.snap
+++ b/packages/plugin/tests/__snapshots__/require-id-when-available.spec.ts.snap
@@ -23,3 +23,17 @@ exports[` 3`] = `
     |         ^ Field "id" or "_id" must be selected when it's available on a type. Please make sure to include it in your selection set!
 If you are using fragments, make sure that all used fragments specifies the field "id" or "_id".
 `;
+
+exports[` 4`] = `
+❌ Error 1/1
+
+  1 |
+  2 |         query User {
+> 3 |           user {
+    |                ^ Field "id" must be selected when it's available on a type. Please make sure to include it in your selection set!
+If you are using fragments, make sure that all used fragments (UserFullFields, UserLightFields) specifies the field "id".
+  4 |             ...UserFullFields
+  5 |           }
+  6 |         }
+  7 |       
+`;

--- a/packages/plugin/tests/require-id-when-available.spec.ts
+++ b/packages/plugin/tests/require-id-when-available.spec.ts
@@ -117,6 +117,54 @@ ruleTester.runGraphQLTests<[RequireIdWhenAvailableRuleConfig]>('require-id-when-
       code: '{ hasId { _id } }',
       options: [{ fieldName: ['id', '_id'] }],
     },
+    {
+      name: 'should work with nested fragments',
+      code: /* GraphQL */ `
+        query User {
+          user {
+            ...UserFullFields
+          }
+        }
+      `,
+      parserOptions: {
+        schema: USER_POST_SCHEMA,
+        operations: `
+          fragment UserLightFields on User {
+            id
+          }
+          fragment UserFullFields on User {
+            ...UserLightFields
+            name
+          }
+        `,
+      },
+    },
+    {
+      name: 'should work with nested fragments n level also',
+      code: /* GraphQL */ `
+        query User {
+          user {
+            ...UserFullFields
+          }
+        }
+      `,
+      parserOptions: {
+        schema: USER_POST_SCHEMA,
+        operations: `
+          fragment UserLightFields on User {
+            id
+          }
+          fragment UserMediumFields on User {
+            ...UserLightFields
+            name
+          }
+          fragment UserFullFields on User {
+            ...UserMediumFields
+            name
+          }
+        `,
+      },
+    },
   ],
   invalid: [
     // TODO: Improve this
@@ -145,6 +193,33 @@ ruleTester.runGraphQLTests<[RequireIdWhenAvailableRuleConfig]>('require-id-when-
       name: 'support multiple id field names',
       code: '{ hasId { name } }',
       options: [{ fieldName: ['id', '_id'] }],
+      errors: [{ messageId: 'REQUIRE_ID_WHEN_AVAILABLE' }],
+    },
+    {
+      name: 'should not work with n nested fragments if you never get the id',
+      code: /* GraphQL */ `
+        query User {
+          user {
+            ...UserFullFields
+          }
+        }
+      `,
+      parserOptions: {
+        schema: USER_POST_SCHEMA,
+        operations: `
+          fragment UserLightFields on User {
+            name
+          }
+          fragment UserMediumFields on User {
+            ...UserLightFields
+            name
+          }
+          fragment UserFullFields on User {
+            ...UserMediumFields
+            name
+          }
+        `,
+      },
       errors: [{ messageId: 'REQUIRE_ID_WHEN_AVAILABLE' }],
     },
   ],


### PR DESCRIPTION
## Description
Check for nested fragments inside fragment to know if the rule require-id-when-available is correct or not

Fixes https://github.com/B2o5T/graphql-eslint/issues/961

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added 3 tests before coding reproducing the issue https://github.com/B2o5T/graphql-eslint/issues/961
- [x] Test 1, valid, should work with nested fragments
- [x] Test 2, valid, should work with nested fragments n level also
- [x] Test 3, invalid, should not work with n nested fragments if you never get the id
- [x] All other tests are still passing

**Test Environment**:
- OS: Windows with WSL (linux)
- `@graphql-eslint/eslint-plugin@3.8.0`:
- NodeJS: `v17.4.0`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

- Nothing to do with this but you could run `prettier`, a few files are not matching. And I don't want to do it in this PR.
- It was a good exercise! :)