### PR TITLE
fix: allow single letter for snake_case and UPPER_CASE in `naming-convention` rule

### DIFF
--- a/.changeset/early-cooks-taste.md
+++ b/.changeset/early-cooks-taste.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix: allow single letter for snake_case and UPPER_CASE in `naming-convention` rule

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -30,8 +30,8 @@ type AllowedStyle = 'camelCase' | 'PascalCase' | 'snake_case' | 'UPPER_CASE';
 const StyleToRegex: Record<AllowedStyle, RegExp> = {
   camelCase: /^[a-z][\dA-Za-z]*$/,
   PascalCase: /^[A-Z][\dA-Za-z]*$/,
-  snake_case: /^[a-z][\d_a-z]*[\da-z]$/,
-  UPPER_CASE: /^[A-Z][\dA-Z_]*[\dA-Z]$/,
+  snake_case: /^[a-z][\d_a-z]*[\da-z]*$/,
+  UPPER_CASE: /^[A-Z][\dA-Z_]*[\dA-Z]*$/,
 };
 
 const ALLOWED_KINDS = Object.keys(KindToDisplayName).sort() as AllowedKind[];

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -140,6 +140,26 @@ ruleTester.runGraphQLTests<[NamingConventionRuleConfig]>('naming-convention', ru
         },
       ],
     },
+    {
+      name: 'should allow single letter for camelCase',
+      code: 'type t',
+      options: [{ ObjectTypeDefinition: 'camelCase' }]
+    },
+    {
+      name: 'should allow single letter for PascalCase',
+      code: 'type T',
+      options: [{ ObjectTypeDefinition: 'PascalCase' }]
+    },
+    {
+      name: 'should allow single letter for snake_case',
+      code: 'type t',
+      options: [{ ObjectTypeDefinition: 'snake_case' }]
+    },
+    {
+      name: 'should allow single letter for UPPER_CASE',
+      code: 'type T',
+      options: [{ ObjectTypeDefinition: 'UPPER_CASE' }]
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
fixes https://github.com/B2o5T/graphql-eslint/issues/1007