### PR TITLE
Support aliases in require-id-when-available

### DIFF
--- a/.changeset/dirty-rules-sin.md
+++ b/.changeset/dirty-rules-sin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+feat: support select `id` field with an alias in `require-id-when-available` rule

--- a/docs/rules/require-id-when-available.md
+++ b/docs/rules/require-id-when-available.md
@@ -50,6 +50,13 @@ query {
     name
   }
 }
+
+# Selecting `id` with an alias is also valid
+query {
+  user {
+    id: name
+  }
+}
 ```
 
 ## Config Schema

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -164,6 +164,10 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
       function hasIdField({ selections }: typeof node): boolean {
         return selections.some(selection => {
           if (selection.kind === Kind.FIELD) {
+            if (selection.alias && idNames.includes(selection.alias.value)) {
+              return true;
+            }
+
             return idNames.includes(selection.name.value);
           }
 

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -70,6 +70,13 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
                 name
               }
             }
+
+            # Selecting \`id\` with an alias is also valid
+            query {
+              user {
+                id: name
+              }
+            }
           `,
         },
       ],

--- a/packages/plugin/tests/require-id-when-available.spec.ts
+++ b/packages/plugin/tests/require-id-when-available.spec.ts
@@ -273,6 +273,7 @@ ruleTester.runGraphQLTests<[RequireIdWhenAvailableRuleConfig], true>('require-id
         `,
       },
     },
+    {name: 'should work when `id` is selected by an alias', ...WITH_SCHEMA, code: '{ hasId {  id: name } }' },
   ],
   invalid: [
     {


### PR DESCRIPTION
## Description

Selecting the `id` field with an alias should also be valid as discussed in #1017 .

Fixes #1017 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (I think)

## How Has This Been Tested?

I've added a test. Do we need more tests?

## Questions

I'm not sure if I should bump the version etc. Should I do that? Or will you perform the changes required for a new release?