### PR TITLE
fix(known-directives): support `ignoreClientDirectives` for `OperationDefinition`

### DIFF
--- a/.changeset/young-stingrays-invite.md
+++ b/.changeset/young-stingrays-invite.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix(known-directives): support `ignoreClientDirectives` for `OperationDefinition`

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -10,6 +10,7 @@ import {
   validate,
   ASTVisitor,
   ExecutableDefinitionNode,
+  DirectiveNode,
 } from 'graphql';
 import { validateSDL } from 'graphql/validation/validate';
 import type { GraphQLESLintRule, GraphQLESLintRuleContext } from '../types';
@@ -231,13 +232,15 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
       if (ignoreClientDirectives.length === 0) {
         return documentNode;
       }
+
+      const filterDirectives = (node: { directives?: ReadonlyArray<DirectiveNode> }) => ({
+        ...node,
+        directives: node.directives.filter(directive => !ignoreClientDirectives.includes(directive.name.value)),
+      });
+
       return visit(documentNode, {
-        Field(node) {
-          return {
-            ...node,
-            directives: node.directives.filter(directive => !ignoreClientDirectives.includes(directive.name.value)),
-          };
-        },
+        Field: filterDirectives,
+        OperationDefinition: filterDirectives,
       });
     },
     {

--- a/packages/plugin/tests/known-directives.spec.ts
+++ b/packages/plugin/tests/known-directives.spec.ts
@@ -34,6 +34,14 @@ ruleTester.runGraphQLTests<[{ ignoreClientDirectives: string[] }]>('known-direct
       `,
       options: [{ ignoreClientDirectives: ['rest'] }],
     },
+    {
+      code: /* GraphQL */ `
+        query @api {
+          test
+        }
+      `,
+      options: [{ ignoreClientDirectives: ['api'] }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
fixes https://github.com/B2o5T/graphql-eslint/issues/1076