### PR TITLE
Missing output property in GraphQLInvalidTestCase

### DIFF
--- a/.changeset/nasty-dancers-act.md
+++ b/.changeset/nasty-dancers-act.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+fix(GraphQLRuleTester): provide output field for `GraphQLInvalidTestCase` type

--- a/packages/plugin/src/testkit.ts
+++ b/packages/plugin/src/testkit.ts
@@ -18,7 +18,7 @@ export type GraphQLValidTestCase<Options> = Omit<RuleTester.ValidTestCase, 'opti
 
 export type GraphQLInvalidTestCase<T> = GraphQLValidTestCase<T> & {
   errors: number | (RuleTester.TestCaseError | string)[];
-  output?: string | null | undefined;
+  output?: string | null;
 };
 
 function indentCode(code: string, indent = 4): string {

--- a/packages/plugin/src/testkit.ts
+++ b/packages/plugin/src/testkit.ts
@@ -18,6 +18,7 @@ export type GraphQLValidTestCase<Options> = Omit<RuleTester.ValidTestCase, 'opti
 
 export type GraphQLInvalidTestCase<T> = GraphQLValidTestCase<T> & {
   errors: number | (RuleTester.TestCaseError | string)[];
+  output?: string | null | undefined;
 };
 
 function indentCode(code: string, indent = 4): string {


### PR DESCRIPTION
## Description

This is just a small TS type tweak to add a missing property to `GraphQLInvalidTestCase`.

If you create your own rule with a `fix` available, eslint throws the following error if the `output` is missing:

```
Message:
      The rule fixed the code. Please add 'output' property.
```

One can add the `output` property to the test case, but the package is missing the type support
```
ruleTester.runGraphQLTests('my-rule', rule, {
    valid: [
        {
            code: /* GraphQL */ `
                type Book {
                    _authorAge: Int! @tag(name: "experimental")
                }
            `,
        },
    ],
    invalid: [
        {
            code: /* GraphQL */ `
                type Book {
                    _authorAge: Int!
                }
            `,
            errors: [
                {
                    message: "The @tag directive is missing.",
                },
            ],
            output: /* GraphQL */ `
                type Book {
                    _authorAge: Int! @tag(name: "experimental")
                }
            `,
        },
    ],
})
```

## Type of change

- [x] New feature (type) (non-breaking change which adds functionality)

I copied over the type declaration from `@types/eslint` (since they don't have an alias for it)

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/missing-output-5r52m7

Just run `yarn test` in the console.

![image](https://user-images.githubusercontent.com/8849858/181523118-bdf77e44-fb14-4715-9cf8-2027cdcbb4f6.png)

## How Has This Been Tested?

`yarn test` and `yarn transpile-ts` were still passing after the changes

**Test Environment**:

- OS: MacOS 12.4 Monterey
- `@graphql-eslint/...`: 3.10.6
- NodeJS: 16
- Eslint: 8.13.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

