### PR TITLE
Fixed type issue for RuleDocsInfo

### DIFF
--- a/.changeset/thin-chicken-doubt.md
+++ b/.changeset/thin-chicken-doubt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+Fix `RuleDocsInfo` type

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -52,7 +52,8 @@ export type GraphQLESLintRuleContext<Options = any[]> = Omit<
 
 export type CategoryType = 'Schema' | 'Operations';
 
-export type RuleDocsInfo<T> = Omit<Rule.RuleMetaData['docs'], 'category' | 'suggestion'> & {
+type RuleMetaDataDocs = Required<Rule.RuleMetaData>['docs']
+export type RuleDocsInfo<T> = Omit<RuleMetaDataDocs, 'category' | 'suggestion'> & {
   category: CategoryType | CategoryType[];
   requiresSchema?: true;
   requiresSiblings?: true;


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Type issue fix for `RuleDocsInfo`

Fixes # (1146)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

 - TS Build errors relating to `description` field is gone (when `strict` flag is turned on)
 - No new TS Build errors

**Test Environment**:

- OS: MacOS Monterey
- `@graphql-eslint/.3.11.2`:
- NodeJS: 16.16

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
