### PR TITLE
Typescript is a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "release": "changeset publish",
     "prettier": "prettier --write --list-different ."
   },
+  "dependencies": {
+    "typescript": "4.8.4"
+  },
   "devDependencies": {
     "@babel/core": "7.19.3",
     "@babel/preset-env": "7.19.3",
@@ -54,8 +57,7 @@
     "patch-package": "6.4.7",
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
-    "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "ts-node": "10.9.1"
   },
   "resolutions": {
     "graphql": "16.6.0"


### PR DESCRIPTION
## Description

Allow to use this plugin in project which doesn't use `typescript`.

Fixes #1180 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Use my fork in a project which don't use `typescript` => typescript is added in `node_modules` as a dependency of this package.

**Test Environment**:

- OS: Archlinux
- `@graphql-eslint/...`: 3.11.2
- NodeJS: 18.9.1

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Following all the checklist process isn't relevant for this change.
