### PR TITLE
fix(cache): Recalculate sibling cache when files change

### DIFF
--- a/packages/plugin/src/parser.ts
+++ b/packages/plugin/src/parser.ts
@@ -21,7 +21,7 @@ export function parseForESLint(code: string, options: ParserOptions = {}): Graph
     const projectForFile = realFilepath ? gqlConfig.getProjectForFile(realFilepath) : gqlConfig.getDefault();
 
     const schema = getSchema(projectForFile, options);
-    const siblingOperations = getSiblingOperations(projectForFile);
+    const siblingOperations = getSiblingOperations(projectForFile, realFilepath);
 
     const { document } = parseGraphQLSDL(filePath, code, {
       ...options.graphQLParserOptions,


### PR DESCRIPTION
## Description

Update the sibling cache to update operations for a given file when that file changes dynamically. This ensures fragments are correctly re-checked when eslint is called multiple times from the same process after a file has changed, like in many editors and when watching client-side builds.

Fixes #1116 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

See https://github.com/B2o5T/graphql-eslint/issues/1116. The fix resolves issues with this test case.

**Test Environment**:

- OS:
- `@graphql-eslint/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- x ] Any dependent changes have been merged and published in downstream modules
