### PR TITLE
extend require-description lint with operation field definitions

### DIFF
--- a/.changeset/good-baboons-bathe.md
+++ b/.changeset/good-baboons-bathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+[require-description] add `rootField` option for only field definitions within `Query`, `Mutation`, and `Subscription` root types

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -48,6 +48,21 @@ mutation createUser {
 }
 ```
 
+### Correct
+
+```graphql
+# eslint @graphql-eslint/require-description: ['error', { rootField: true }]
+
+type Mutation {
+  "Create a new user"
+  createUser: User
+}
+
+type User {
+  name: String
+}
+```
+
 ## Config Schema
 
 The schema defines the following properties:
@@ -62,6 +77,10 @@ Includes:
 - `ScalarTypeDefinition`
 - `InputObjectTypeDefinition`
 - `UnionTypeDefinition`
+
+### `rootField` (boolean)
+
+Definitions within `Query`, `Mutation`, and `Subscription` root types
 
 ### `DirectiveDefinition` (boolean)
 

--- a/packages/plugin/src/rules/alphabetize.ts
+++ b/packages/plugin/src/rules/alphabetize.ts
@@ -57,7 +57,7 @@ export type AlphabetizeConfig = {
   definitions?: boolean;
 };
 
-const rule: GraphQLESLintRule<[AlphabetizeConfig]> = {
+export const rule: GraphQLESLintRule<[AlphabetizeConfig]> = {
   meta: {
     type: 'suggestion',
     fixable: 'code',
@@ -402,5 +402,3 @@ const rule: GraphQLESLintRule<[AlphabetizeConfig]> = {
     return listeners;
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/description-style.ts
+++ b/packages/plugin/src/rules/description-style.ts
@@ -4,7 +4,7 @@ import { GraphQLESTreeNode } from '../estree-converter';
 
 type DescriptionStyleRuleConfig = { style: 'inline' | 'block' };
 
-const rule: GraphQLESLintRule<[DescriptionStyleRuleConfig]> = {
+export const rule: GraphQLESLintRule<[DescriptionStyleRuleConfig]> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -77,5 +77,3 @@ const rule: GraphQLESLintRule<[DescriptionStyleRuleConfig]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -158,7 +158,7 @@ const validationToRule = (
           ...docs,
           graphQLJSRuleName: ruleName,
           url: `https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/${ruleId}.md`,
-          description: `${docs.description}\n\n> This rule is a wrapper around a \`graphql-js\` validation function.`,
+          description: `${docs.description}\n> This rule is a wrapper around a \`graphql-js\` validation function.`,
         },
         schema,
       },

--- a/packages/plugin/src/rules/index.ts
+++ b/packages/plugin/src/rules/index.ts
@@ -3,34 +3,34 @@
  */
 
 import { GRAPHQL_JS_VALIDATIONS } from './graphql-js-validation';
-import alphabetize from './alphabetize';
-import descriptionStyle from './description-style';
-import inputName from './input-name';
-import matchDocumentFilename from './match-document-filename';
-import namingConvention from './naming-convention';
-import noAnonymousOperations from './no-anonymous-operations';
-import noCaseInsensitiveEnumValuesDuplicates from './no-case-insensitive-enum-values-duplicates';
-import noDeprecated from './no-deprecated';
-import noDuplicateFields from './no-duplicate-fields';
-import noHashtagDescription from './no-hashtag-description';
-import noRootType from './no-root-type';
-import noScalarResultTypeOnMutation from './no-scalar-result-type-on-mutation';
-import noTypenamePrefix from './no-typename-prefix';
-import noUnreachableTypes from './no-unreachable-types';
-import noUnusedFields from './no-unused-fields';
-import relayArguments from './relay-arguments';
-import relayConnectionTypes from './relay-connection-types';
-import relayEdgeTypes from './relay-edge-types';
-import relayPageInfo from './relay-page-info';
-import requireDeprecationDate from './require-deprecation-date';
-import requireDeprecationReason from './require-deprecation-reason';
-import requireDescription from './require-description';
-import requireFieldOfTypeQueryInMutationResult from './require-field-of-type-query-in-mutation-result';
-import requireIdWhenAvailable from './require-id-when-available';
-import selectionSetDepth from './selection-set-depth';
-import strictIdInTypes from './strict-id-in-types';
-import uniqueFragmentName from './unique-fragment-name';
-import uniqueOperationName from './unique-operation-name';
+import { rule as alphabetize } from './alphabetize';
+import { rule as descriptionStyle } from './description-style';
+import { rule as inputName } from './input-name';
+import { rule as matchDocumentFilename } from './match-document-filename';
+import { rule as namingConvention } from './naming-convention';
+import { rule as noAnonymousOperations } from './no-anonymous-operations';
+import { rule as noCaseInsensitiveEnumValuesDuplicates } from './no-case-insensitive-enum-values-duplicates';
+import { rule as noDeprecated } from './no-deprecated';
+import { rule as noDuplicateFields } from './no-duplicate-fields';
+import { rule as noHashtagDescription } from './no-hashtag-description';
+import { rule as noRootType } from './no-root-type';
+import { rule as noScalarResultTypeOnMutation } from './no-scalar-result-type-on-mutation';
+import { rule as noTypenamePrefix } from './no-typename-prefix';
+import { rule as noUnreachableTypes } from './no-unreachable-types';
+import { rule as noUnusedFields } from './no-unused-fields';
+import { rule as relayArguments } from './relay-arguments';
+import { rule as relayConnectionTypes } from './relay-connection-types';
+import { rule as relayEdgeTypes } from './relay-edge-types';
+import { rule as relayPageInfo } from './relay-page-info';
+import { rule as requireDeprecationDate } from './require-deprecation-date';
+import { rule as requireDeprecationReason } from './require-deprecation-reason';
+import { rule as requireDescription } from './require-description';
+import { rule as requireFieldOfTypeQueryInMutationResult } from './require-field-of-type-query-in-mutation-result';
+import { rule as requireIdWhenAvailable } from './require-id-when-available';
+import { rule as selectionSetDepth } from './selection-set-depth';
+import { rule as strictIdInTypes } from './strict-id-in-types';
+import { rule as uniqueFragmentName } from './unique-fragment-name';
+import { rule as uniqueOperationName } from './unique-operation-name';
 
 export const rules = {
   ...GRAPHQL_JS_VALIDATIONS,

--- a/packages/plugin/src/rules/input-name.ts
+++ b/packages/plugin/src/rules/input-name.ts
@@ -25,7 +25,7 @@ const isQueryType = (node: ObjectTypeNode): boolean =>
 const isMutationType = (node: ObjectTypeNode): boolean =>
   isObjectType(node) && node.name.value === 'Mutation';
 
-const rule: GraphQLESLintRule<[InputNameRuleConfig]> = {
+export const rule: GraphQLESLintRule<[InputNameRuleConfig]> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -164,5 +164,3 @@ const rule: GraphQLESLintRule<[InputNameRuleConfig]> = {
     return listeners;
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/match-document-filename.ts
+++ b/packages/plugin/src/rules/match-document-filename.ts
@@ -37,7 +37,7 @@ const schemaOption = {
   oneOf: [{ $ref: '#/definitions/asString' }, { $ref: '#/definitions/asObject' }],
 };
 
-const rule: GraphQLESLintRule<[MatchDocumentFilenameRuleConfig]> = {
+export const rule: GraphQLESLintRule<[MatchDocumentFilenameRuleConfig]> = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -244,5 +244,3 @@ const rule: GraphQLESLintRule<[MatchDocumentFilenameRuleConfig]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -62,7 +62,7 @@ export type NamingConventionRuleConfig = {
 
 type AllowedKindToNode = Pick<ASTKindToNode, AllowedKind>;
 
-const rule: GraphQLESLintRule<[NamingConventionRuleConfig]> = {
+export const rule: GraphQLESLintRule<[NamingConventionRuleConfig]> = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -208,7 +208,7 @@ const rule: GraphQLESLintRule<[NamingConventionRuleConfig]> = {
         properties: {
           types: {
             ...schemaOption,
-            description: `Includes:\n\n${TYPES_KINDS.map(kind => `- \`${kind}\``).join('\n')}`,
+            description: `Includes:\n${TYPES_KINDS.map(kind => `- \`${kind}\``).join('\n')}`,
           },
           ...Object.fromEntries(
             ALLOWED_KINDS.map(kind => [
@@ -365,5 +365,3 @@ const rule: GraphQLESLintRule<[NamingConventionRuleConfig]> = {
     return listeners;
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-anonymous-operations.ts
+++ b/packages/plugin/src/rules/no-anonymous-operations.ts
@@ -5,7 +5,7 @@ import { GraphQLESTreeNode } from '../estree-converter';
 
 const RULE_ID = 'no-anonymous-operations';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -75,5 +75,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-case-insensitive-enum-values-duplicates.ts
+++ b/packages/plugin/src/rules/no-case-insensitive-enum-values-duplicates.ts
@@ -2,7 +2,7 @@ import { EnumTypeDefinitionNode, EnumTypeExtensionNode, Kind } from 'graphql';
 import { GraphQLESTreeNode } from '../estree-converter';
 import { GraphQLESLintRule } from '../types';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -62,5 +62,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-deprecated.ts
+++ b/packages/plugin/src/rules/no-deprecated.ts
@@ -5,7 +5,7 @@ import type { GraphQLESTreeNode } from '../estree-converter';
 
 const RULE_ID = 'no-deprecated';
 
-const rule: GraphQLESLintRule<[], true> = {
+export const rule: GraphQLESLintRule<[], true> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -129,5 +129,3 @@ const rule: GraphQLESLintRule<[], true> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-duplicate-fields.ts
+++ b/packages/plugin/src/rules/no-duplicate-fields.ts
@@ -4,7 +4,7 @@ import type { GraphQLESTreeNode } from '../estree-converter';
 
 const RULE_ID = 'no-duplicate-fields';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -114,5 +114,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-hashtag-description.ts
+++ b/packages/plugin/src/rules/no-hashtag-description.ts
@@ -4,7 +4,7 @@ import { GraphQLESTreeNode } from '../estree-converter';
 
 const HASHTAG_COMMENT = 'HASHTAG_COMMENT';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -98,5 +98,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-root-type.ts
+++ b/packages/plugin/src/rules/no-root-type.ts
@@ -7,7 +7,7 @@ const ROOT_TYPES: ('mutation' | 'subscription')[] = ['mutation', 'subscription']
 
 type NoRootTypeConfig = { disallow: typeof ROOT_TYPES };
 
-const rule: GraphQLESLintRule<[NoRootTypeConfig]> = {
+export const rule: GraphQLESLintRule<[NoRootTypeConfig]> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -92,5 +92,3 @@ const rule: GraphQLESLintRule<[NoRootTypeConfig]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-scalar-result-type-on-mutation.ts
+++ b/packages/plugin/src/rules/no-scalar-result-type-on-mutation.ts
@@ -5,7 +5,7 @@ import { GraphQLESTreeNode } from '../estree-converter';
 
 const RULE_ID = 'no-scalar-result-type-on-mutation';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -67,5 +67,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-typename-prefix.ts
+++ b/packages/plugin/src/rules/no-typename-prefix.ts
@@ -9,7 +9,7 @@ import { GraphQLESLintRule } from '../types';
 
 const NO_TYPENAME_PREFIX = 'NO_TYPENAME_PREFIX';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -85,5 +85,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-unreachable-types.ts
+++ b/packages/plugin/src/rules/no-unreachable-types.ts
@@ -105,7 +105,7 @@ function getReachableTypes(schema: GraphQLSchema): ReachableTypes {
   return reachableTypesCache;
 }
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     messages: {
       [RULE_ID]: '{{ type }} `{{ typeName }}` is unreachable.',
@@ -178,5 +178,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/no-unused-fields.ts
+++ b/packages/plugin/src/rules/no-unused-fields.ts
@@ -41,7 +41,7 @@ function getUsedFields(schema: GraphQLSchema, operations: SiblingOperations): Us
   return usedFieldsCache;
 }
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     messages: {
       [RULE_ID]: 'Field "{{fieldName}}" is unused',
@@ -137,5 +137,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/relay-arguments.ts
+++ b/packages/plugin/src/rules/relay-arguments.ts
@@ -8,7 +8,7 @@ const MISSING_ARGUMENTS = 'MISSING_ARGUMENTS';
 
 export type RelayArgumentsConfig = { includeBoth?: boolean };
 
-const rule: GraphQLESLintRule<[RelayArgumentsConfig], true> = {
+export const rule: GraphQLESLintRule<[RelayArgumentsConfig], true> = {
   meta: {
     type: 'problem',
     docs: {
@@ -133,5 +133,3 @@ const rule: GraphQLESLintRule<[RelayArgumentsConfig], true> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/relay-connection-types.ts
+++ b/packages/plugin/src/rules/relay-connection-types.ts
@@ -28,7 +28,7 @@ const hasEdgesField = (node: GraphQLESTreeNode<ObjectTypeDefinitionNode>) =>
 const hasPageInfoField = (node: GraphQLESTreeNode<ObjectTypeDefinitionNode>) =>
   node.fields.some(field => field.name.value === 'pageInfo');
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'problem',
     docs: {
@@ -124,5 +124,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/relay-edge-types.ts
+++ b/packages/plugin/src/rules/relay-edge-types.ts
@@ -61,7 +61,7 @@ export type EdgeTypesConfig = {
   listTypeCanWrapOnlyEdgeType?: boolean;
 };
 
-const rule: GraphQLESLintRule<[EdgeTypesConfig], true> = {
+export const rule: GraphQLESLintRule<[EdgeTypesConfig], true> = {
   meta: {
     type: 'problem',
     docs: {
@@ -223,5 +223,3 @@ const rule: GraphQLESLintRule<[EdgeTypesConfig], true> = {
     return listeners;
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/relay-page-info.ts
+++ b/packages/plugin/src/rules/relay-page-info.ts
@@ -11,7 +11,7 @@ const notPageInfoTypesSelector = `:matches(${NON_OBJECT_TYPES})[name.value=PageI
 
 let hasPageInfoChecked = false;
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'problem',
     docs: {
@@ -108,5 +108,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/require-deprecation-date.ts
+++ b/packages/plugin/src/rules/require-deprecation-date.ts
@@ -10,7 +10,7 @@ const MESSAGE_INVALID_FORMAT = 'MESSAGE_INVALID_FORMAT';
 const MESSAGE_INVALID_DATE = 'MESSAGE_INVALID_DATE';
 const MESSAGE_CAN_BE_REMOVED = 'MESSAGE_CAN_BE_REMOVED';
 
-const rule: GraphQLESLintRule<[{ argumentName?: string }]> = {
+export const rule: GraphQLESLintRule<[{ argumentName?: string }]> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -125,5 +125,3 @@ const rule: GraphQLESLintRule<[{ argumentName?: string }]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/require-deprecation-reason.ts
+++ b/packages/plugin/src/rules/require-deprecation-reason.ts
@@ -2,7 +2,7 @@ import type { ArgumentNode, DirectiveNode } from 'graphql';
 import type { GraphQLESLintRule } from '../types';
 import { GraphQLESTreeNode, valueFromNode } from '../estree-converter';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     docs: {
       description: 'Require all deprecation directives to specify a reason.',
@@ -57,5 +57,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/require-description.ts
+++ b/packages/plugin/src/rules/require-description.ts
@@ -163,7 +163,7 @@ const rule: GraphQLESLintRule<[RequireDescriptionRuleConfig]> = {
     }
 
     if (operationFieldDefinition) {
-      kinds.add(':matches(ObjectTypeDefinition, ObjectTypeExtension) > FieldDefinition');
+      kinds.add(':matches(ObjectTypeDefinition, ObjectTypeExtension)[name.value=/Query|Mutation|Subscription/] > FieldDefinition');
     }
 
     const selector = [...kinds].join(',');

--- a/packages/plugin/src/rules/require-field-of-type-query-in-mutation-result.ts
+++ b/packages/plugin/src/rules/require-field-of-type-query-in-mutation-result.ts
@@ -5,7 +5,7 @@ import type { GraphQLESTreeNode } from '../estree-converter';
 
 const RULE_ID = 'require-field-of-type-query-in-mutation-result';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -75,5 +75,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -28,7 +28,6 @@ const DEFAULT_ID_FIELD_NAME = 'id';
 export const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
   meta: {
     type: 'suggestion',
-    // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions
     hasSuggestions: true,
     docs: {
       category: 'Operations',

--- a/packages/plugin/src/rules/require-id-when-available.ts
+++ b/packages/plugin/src/rules/require-id-when-available.ts
@@ -25,7 +25,7 @@ export type RequireIdWhenAvailableRuleConfig = { fieldName: string | string[] };
 const RULE_ID = 'require-id-when-available';
 const DEFAULT_ID_FIELD_NAME = 'id';
 
-const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
+export const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
   meta: {
     type: 'suggestion',
     // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions
@@ -251,5 +251,3 @@ const rule: GraphQLESLintRule<[RequireIdWhenAvailableRuleConfig], true> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/selection-set-depth.ts
+++ b/packages/plugin/src/rules/selection-set-depth.ts
@@ -10,7 +10,7 @@ export type SelectionSetDepthRuleConfig = { maxDepth: number; ignore?: string[] 
 
 const RULE_ID = 'selection-set-depth';
 
-const rule: GraphQLESLintRule<[SelectionSetDepthRuleConfig]> = {
+export const rule: GraphQLESLintRule<[SelectionSetDepthRuleConfig]> = {
   meta: {
     type: 'suggestion',
     hasSuggestions: true,
@@ -150,5 +150,3 @@ const rule: GraphQLESLintRule<[SelectionSetDepthRuleConfig]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/strict-id-in-types.ts
+++ b/packages/plugin/src/rules/strict-id-in-types.ts
@@ -14,7 +14,7 @@ export type StrictIdInTypesRuleConfig = {
 
 const RULE_ID = 'strict-id-in-types';
 
-const rule: GraphQLESLintRule<[StrictIdInTypesRuleConfig]> = {
+export const rule: GraphQLESLintRule<[StrictIdInTypesRuleConfig]> = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -183,5 +183,3 @@ const rule: GraphQLESLintRule<[StrictIdInTypesRuleConfig]> = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/unique-fragment-name.ts
+++ b/packages/plugin/src/rules/unique-fragment-name.ts
@@ -40,7 +40,7 @@ export const checkNode = (
   }
 };
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -96,5 +96,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/rules/unique-operation-name.ts
+++ b/packages/plugin/src/rules/unique-operation-name.ts
@@ -3,7 +3,7 @@ import { checkNode } from './unique-fragment-name';
 
 const RULE_ID = 'unique-operation-name';
 
-const rule: GraphQLESLintRule = {
+export const rule: GraphQLESLintRule = {
   meta: {
     type: 'suggestion',
     docs: {
@@ -63,5 +63,3 @@ const rule: GraphQLESLintRule = {
     };
   },
 };
-
-export default rule;

--- a/packages/plugin/src/testkit.ts
+++ b/packages/plugin/src/testkit.ts
@@ -16,7 +16,7 @@ export type GraphQLValidTestCase<Options> = Omit<
   'options' | 'parserOptions'
 > & {
   options?: Options;
-  parserOptions?: ParserOptions;
+  parserOptions?: Omit<ParserOptions, 'filePath'>;
 };
 
 export type GraphQLInvalidTestCase<T> = GraphQLValidTestCase<T> & {

--- a/packages/plugin/tests/__snapshots__/require-description.spec.md
+++ b/packages/plugin/tests/__snapshots__/require-description.spec.md
@@ -178,7 +178,7 @@ exports[`Invalid #17 1`] = `
 #### ⚙️ Options
 
     {
-      "operationFieldDefinition": true
+      "rootField": true
     }
 
 #### ❌ Error
@@ -190,29 +190,12 @@ exports[`Invalid #17 1`] = `
 exports[`Invalid #18 1`] = `
 #### ⌨️ Code
 
-      1 | type Query { users: [User!]! }
-
-#### ⚙️ Options
-
-    {
-      "operationFieldDefinition": true
-    }
-
-#### ❌ Error
-
-    > 1 | type Query { users: [User!]! }
-        |              ^^^^^ Description is required for \`Query.users\`.
-`;
-
-exports[`Invalid #19 1`] = `
-#### ⌨️ Code
-
       1 | type Mutation { createUser(user: UserInput): User! }
 
 #### ⚙️ Options
 
     {
-      "operationFieldDefinition": true
+      "rootField": true
     }
 
 #### ❌ Error
@@ -221,7 +204,7 @@ exports[`Invalid #19 1`] = `
         |                 ^^^^^^^^^^ Description is required for \`Mutation.createUser\`.
 `;
 
-exports[`Invalid #20 1`] = `
+exports[`Invalid #19 1`] = `
 #### ⌨️ Code
 
       1 | type Subscription { users: [User!] }
@@ -229,7 +212,7 @@ exports[`Invalid #20 1`] = `
 #### ⚙️ Options
 
     {
-      "operationFieldDefinition": true
+      "rootField": true
     }
 
 #### ❌ Error

--- a/packages/plugin/tests/__snapshots__/require-description.spec.md
+++ b/packages/plugin/tests/__snapshots__/require-description.spec.md
@@ -170,6 +170,40 @@ exports[`Invalid #10 1`] = `
         |             ^^^^^ Description is required for \`Role.ADMIN\`.
 `;
 
+exports[`Invalid #17 1`] = `
+#### ⌨️ Code
+
+      1 | type Query { user(id: String!): User! }
+
+#### ⚙️ Options
+
+    {
+      "operationFieldDefinition": true
+    }
+
+#### ❌ Error
+
+    > 1 | type Query { user(id: String!): User! }
+        |              ^^^^ Description is required for \`Query.user\`.
+`;
+
+exports[`Invalid #18 1`] = `
+#### ⌨️ Code
+
+      1 | type Query { users: [User!]! }
+
+#### ⚙️ Options
+
+    {
+      "operationFieldDefinition": true
+    }
+
+#### ❌ Error
+
+    > 1 | type Query { users: [User!]! }
+        |              ^^^^^ Description is required for \`Query.users\`.
+`;
+
 exports[`should disable description for ObjectTypeDefinition 1`] = `
 #### ⌨️ Code
 

--- a/packages/plugin/tests/__snapshots__/require-description.spec.md
+++ b/packages/plugin/tests/__snapshots__/require-description.spec.md
@@ -204,6 +204,40 @@ exports[`Invalid #18 1`] = `
         |              ^^^^^ Description is required for \`Query.users\`.
 `;
 
+exports[`Invalid #19 1`] = `
+#### ⌨️ Code
+
+      1 | type Mutation { createUser(user: UserInput): User! }
+
+#### ⚙️ Options
+
+    {
+      "operationFieldDefinition": true
+    }
+
+#### ❌ Error
+
+    > 1 | type Mutation { createUser(user: UserInput): User! }
+        |                 ^^^^^^^^^^ Description is required for \`Mutation.createUser\`.
+`;
+
+exports[`Invalid #20 1`] = `
+#### ⌨️ Code
+
+      1 | type Subscription { users: [User!] }
+
+#### ⚙️ Options
+
+    {
+      "operationFieldDefinition": true
+    }
+
+#### ❌ Error
+
+    > 1 | type Subscription { users: [User!] }
+        |                     ^^^^^ Description is required for \`Subscription.users\`.
+`;
+
 exports[`should disable description for ObjectTypeDefinition 1`] = `
 #### ⌨️ Code
 

--- a/packages/plugin/tests/__snapshots__/require-description.spec.md
+++ b/packages/plugin/tests/__snapshots__/require-description.spec.md
@@ -190,7 +190,7 @@ exports[`Invalid #17 1`] = `
 exports[`Invalid #18 1`] = `
 #### ⌨️ Code
 
-      1 | type Mutation { createUser(user: UserInput): User! }
+      1 | type Mutation { createUser(id: [ID!]!): User! }
 
 #### ⚙️ Options
 
@@ -200,14 +200,19 @@ exports[`Invalid #18 1`] = `
 
 #### ❌ Error
 
-    > 1 | type Mutation { createUser(user: UserInput): User! }
+    > 1 | type Mutation { createUser(id: [ID!]!): User! }
         |                 ^^^^^^^^^^ Description is required for \`Mutation.createUser\`.
 `;
 
 exports[`Invalid #19 1`] = `
 #### ⌨️ Code
 
-      1 | type Subscription { users: [User!] }
+      1 |         type MySubscription {
+      2 |           users: [User!]!
+      3 |         }
+      4 |         schema {
+      5 |           subscription: MySubscription
+      6 |         }
 
 #### ⚙️ Options
 
@@ -217,8 +222,10 @@ exports[`Invalid #19 1`] = `
 
 #### ❌ Error
 
-    > 1 | type Subscription { users: [User!] }
-        |                     ^^^^^ Description is required for \`Subscription.users\`.
+      1 |         type MySubscription {
+    > 2 |           users: [User!]!
+        |           ^^^^^ Description is required for \`MySubscription.users\`.
+      3 |         }
 `;
 
 exports[`should disable description for ObjectTypeDefinition 1`] = `

--- a/packages/plugin/tests/alphabetize.spec.ts
+++ b/packages/plugin/tests/alphabetize.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule, { AlphabetizeConfig } from '../src/rules/alphabetize';
+import { rule, AlphabetizeConfig } from '../src/rules/alphabetize';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/description-style.spec.ts
+++ b/packages/plugin/tests/description-style.spec.ts
@@ -1,5 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
-import rule from '../src/rules/description-style';
+import { GraphQLRuleTester } from '../src';
+import { rule } from '../src/rules/description-style';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/eslint-directives.spec.ts
+++ b/packages/plugin/tests/eslint-directives.spec.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { GraphQLRuleTester } from '../src';
-import noAnonymousOperations from '../src/rules/no-anonymous-operations';
-import noTypenamePrefix from '../src/rules/no-typename-prefix';
+import { rule as noAnonymousOperations } from '../src/rules/no-anonymous-operations';
+import { rule as noTypenamePrefix } from '../src/rules/no-typename-prefix';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/executable-definitions.spec.ts
+++ b/packages/plugin/tests/executable-definitions.spec.ts
@@ -1,6 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
+import { GraphQLRuleTester, ParserOptions } from '../src';
 import { GRAPHQL_JS_VALIDATIONS } from '../src/rules/graphql-js-validation';
-import { ParserOptions } from '../src/types';
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {

--- a/packages/plugin/tests/fields-on-correct-type.spec.ts
+++ b/packages/plugin/tests/fields-on-correct-type.spec.ts
@@ -1,6 +1,6 @@
 import { GraphQLRuleTester, rules, ParserOptions } from '../src';
 
-const parserOptions: ParserOptions = {
+const parserOptions: Pick<ParserOptions, 'schema'> = {
   schema: /* GraphQL */ `
     type User {
       id: ID

--- a/packages/plugin/tests/input-name.spec.ts
+++ b/packages/plugin/tests/input-name.spec.ts
@@ -1,5 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
-import rule from '../src/rules/input-name';
+import { GraphQLRuleTester } from '../src';
+import { rule } from '../src/rules/input-name';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/match-document-filename.spec.ts
+++ b/packages/plugin/tests/match-document-filename.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule, { MatchDocumentFilenameRuleConfig } from '../src/rules/match-document-filename';
+import { rule, MatchDocumentFilenameRuleConfig } from '../src/rules/match-document-filename';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule, { NamingConventionRuleConfig } from '../src/rules/naming-convention';
+import { rule, NamingConventionRuleConfig } from '../src/rules/naming-convention';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-anonymous-operations.spec.ts
+++ b/packages/plugin/tests/no-anonymous-operations.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/no-anonymous-operations';
+import { rule } from '../src/rules/no-anonymous-operations';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-case-insensitive-enum-values-duplicates.spec.ts
+++ b/packages/plugin/tests/no-case-insensitive-enum-values-duplicates.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/no-case-insensitive-enum-values-duplicates';
+import { rule } from '../src/rules/no-case-insensitive-enum-values-duplicates';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-deprecated.spec.ts
+++ b/packages/plugin/tests/no-deprecated.spec.ts
@@ -1,6 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
-import rule from '../src/rules/no-deprecated';
-import { ParserOptions } from '../src/types';
+import { GraphQLRuleTester, ParserOptions } from '../src';
+import { rule } from '../src/rules/no-deprecated';
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {

--- a/packages/plugin/tests/no-duplicate-fields.spec.ts
+++ b/packages/plugin/tests/no-duplicate-fields.spec.ts
@@ -1,5 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
-import rule from '../src/rules/no-duplicate-fields';
+import { GraphQLRuleTester } from '../src';
+import { rule } from '../src/rules/no-duplicate-fields';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-hashtag-description.spec.ts
+++ b/packages/plugin/tests/no-hashtag-description.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/no-hashtag-description';
+import { rule } from '../src/rules/no-hashtag-description';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-root-type.spec.ts
+++ b/packages/plugin/tests/no-root-type.spec.ts
@@ -1,7 +1,10 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/no-root-type';
+import { rule } from '../src/rules/no-root-type';
 
-const useSchema = (code: string, schema = ''): { code: string; parserOptions: ParserOptions } => ({
+const useSchema = (
+  code: string,
+  schema = '',
+): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => ({
   code,
   parserOptions: {
     schema: schema + code,

--- a/packages/plugin/tests/no-scalar-result-type-on-mutation.spec.ts
+++ b/packages/plugin/tests/no-scalar-result-type-on-mutation.spec.ts
@@ -1,7 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/no-scalar-result-type-on-mutation';
+import { rule } from '../src/rules/no-scalar-result-type-on-mutation';
 
-const useSchema = (code: string): { code: string; parserOptions: ParserOptions } => ({
+const useSchema = (
+  code: string,
+): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => ({
   code,
   parserOptions: {
     schema: /* GraphQL */ `

--- a/packages/plugin/tests/no-typename-prefix.spec.ts
+++ b/packages/plugin/tests/no-typename-prefix.spec.ts
@@ -1,5 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
-import rule from '../src/rules/no-typename-prefix';
+import { GraphQLRuleTester } from '../src';
+import { rule } from '../src/rules/no-typename-prefix';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/no-unreachable-types.spec.ts
+++ b/packages/plugin/tests/no-unreachable-types.spec.ts
@@ -1,7 +1,7 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/no-unreachable-types';
+import { rule } from '../src/rules/no-unreachable-types';
 
-const useSchema = (schema: string): { code: string; parserOptions: ParserOptions } => {
+const useSchema = (schema: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => {
   return {
     parserOptions: { schema },
     code: schema,

--- a/packages/plugin/tests/no-unused-fields.spec.ts
+++ b/packages/plugin/tests/no-unused-fields.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/no-unused-fields';
+import { rule } from '../src/rules/no-unused-fields';
 
 const SCHEMA = /* GraphQL */ `
   type User {

--- a/packages/plugin/tests/possible-type-extension.spec.ts
+++ b/packages/plugin/tests/possible-type-extension.spec.ts
@@ -3,10 +3,10 @@ import { GraphQLRuleTester, rules, ParserOptions } from '../src';
 
 const ruleTester = new GraphQLRuleTester();
 
-const useUserSchema = (code: string) => {
+const useUserSchema = (code: string): { code: string, parserOptions: Pick<ParserOptions, 'schema'> } => {
   return {
     code,
-    parserOptions: <ParserOptions>{
+    parserOptions: {
       schema: /* GraphQL */ `
         type User {
           id: ID

--- a/packages/plugin/tests/relay-arguments.spec.ts
+++ b/packages/plugin/tests/relay-arguments.spec.ts
@@ -1,9 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule, { RelayArgumentsConfig } from '../src/rules/relay-arguments';
+import { rule, RelayArgumentsConfig } from '../src/rules/relay-arguments';
 
 const ruleTester = new GraphQLRuleTester();
 
-function useSchema(code: string): { code: string; parserOptions: ParserOptions } {
+function useSchema(code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } {
   return {
     code,
     parserOptions: {

--- a/packages/plugin/tests/relay-connection-types.spec.ts
+++ b/packages/plugin/tests/relay-connection-types.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/relay-connection-types';
+import { rule } from '../src/rules/relay-connection-types';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/relay-edge-types.spec.ts
+++ b/packages/plugin/tests/relay-edge-types.spec.ts
@@ -1,9 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule, { EdgeTypesConfig } from '../src/rules/relay-edge-types';
+import { rule, EdgeTypesConfig } from '../src/rules/relay-edge-types';
 
 const ruleTester = new GraphQLRuleTester();
 
-function useSchema(code: string): { code: string; parserOptions: ParserOptions } {
+function useSchema(code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } {
   return {
     code,
     parserOptions: {

--- a/packages/plugin/tests/relay-page-info.spec.ts
+++ b/packages/plugin/tests/relay-page-info.spec.ts
@@ -1,9 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/relay-page-info';
+import { rule } from '../src/rules/relay-page-info';
 
 const ruleTester = new GraphQLRuleTester();
 
-function useSchema(code: string): { code: string; parserOptions: ParserOptions } {
+function useSchema(code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } {
   return {
     code,
     parserOptions: {

--- a/packages/plugin/tests/require-deprecation-date.spec.ts
+++ b/packages/plugin/tests/require-deprecation-date.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/require-deprecation-date';
+import { rule } from '../src/rules/require-deprecation-date';
 
 const now = new Date();
 now.setDate(now.getDate() + 1);

--- a/packages/plugin/tests/require-deprecation-reason.spec.ts
+++ b/packages/plugin/tests/require-deprecation-reason.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/require-deprecation-reason';
+import { rule } from '../src/rules/require-deprecation-reason';
 
 const ruleTester = new GraphQLRuleTester();
 

--- a/packages/plugin/tests/require-description.spec.ts
+++ b/packages/plugin/tests/require-description.spec.ts
@@ -83,7 +83,7 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
           name: String
         }
       `,
-      options: [{ operationFieldDefinition: true }],
+      options: [{ rootField: true }],
     },
     {
       code: /* GraphQL */ `
@@ -92,7 +92,15 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
           users: [User!]!
         }
       `,
-      options: [{ operationFieldDefinition: true }],
+      options: [{ rootField: true }],
+    },
+    {
+      code: /* GraphQL */ `
+        type User {
+          name: String
+        }
+      `,
+      options: [{ rootField: true }],
     },
   ],
   invalid: [
@@ -220,22 +228,17 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
     },
     {
       code: 'type Query { user(id: String!): User! }',
-      options: [{ operationFieldDefinition: true }],
+      options: [{ rootField: true }],
       errors: [{ message: 'Description is required for `Query.user`.' }],
     },
     {
-      code: 'type Query { users: [User!]! }',
-      options: [{ operationFieldDefinition: true }],
-      errors: [{ message: 'Description is required for `Query.users`.' }],
-    },
-    {
       code: 'type Mutation { createUser(user: UserInput): User! }',
-      options: [{ operationFieldDefinition: true }],
+      options: [{ rootField: true }],
       errors: [{ message: 'Description is required for `Mutation.createUser`.' }],
     },
     {
       code: 'type Subscription { users: [User!] }',
-      options: [{ operationFieldDefinition: true }],
+      options: [{ rootField: true }],
       errors: [{ message: 'Description is required for `Subscription.users`.' }],
     },
   ],

--- a/packages/plugin/tests/require-description.spec.ts
+++ b/packages/plugin/tests/require-description.spec.ts
@@ -79,6 +79,9 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
           "Get user"
           user(id: ID!): User
         }
+        type User {
+          name: String
+        }
       `,
       options: [{ operationFieldDefinition: true }],
     },
@@ -224,6 +227,16 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
       code: 'type Query { users: [User!]! }',
       options: [{ operationFieldDefinition: true }],
       errors: [{ message: 'Description is required for `Query.users`.' }],
+    },
+    {
+      code: 'type Mutation { createUser(user: UserInput): User! }',
+      options: [{ operationFieldDefinition: true }],
+      errors: [{ message: 'Description is required for `Mutation.createUser`.' }],
+    },
+    {
+      code: 'type Subscription { users: [User!] }',
+      options: [{ operationFieldDefinition: true }],
+      errors: [{ message: 'Description is required for `Subscription.users`.' }],
     },
   ],
 });

--- a/packages/plugin/tests/require-description.spec.ts
+++ b/packages/plugin/tests/require-description.spec.ts
@@ -73,6 +73,24 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
       `,
       options: [OPERATION],
     },
+    {
+      code: /* GraphQL */ `
+        type Query {
+          "Get user"
+          user(id: ID!): User
+        }
+      `,
+      options: [{ operationFieldDefinition: true }],
+    },
+    {
+      code: /* GraphQL */ `
+        type Query {
+          "Get users"
+          user: [User!]!
+        }
+      `,
+      options: [{ operationFieldDefinition: true }],
+    },
   ],
   invalid: [
     {
@@ -196,6 +214,16 @@ ruleTester.runGraphQLTests<[RequireDescriptionRuleConfig]>('require-description'
       `,
       options: [OPERATION],
       errors: [{ message: 'Description is required for `query`.' }],
+    },
+    {
+      code: 'type Query { user(id: String!): User! }',
+      options: [{ operationFieldDefinition: true }],
+      errors: [{ message: 'Description is required for `Query.user`.' }],
+    },
+    {
+      code: 'type Query { users: [User!]! }',
+      options: [{ operationFieldDefinition: true }],
+      errors: [{ message: 'Description is required for `Query.users`.' }],
     },
   ],
 });

--- a/packages/plugin/tests/require-field-of-type-query-in-mutation-result.spec.ts
+++ b/packages/plugin/tests/require-field-of-type-query-in-mutation-result.spec.ts
@@ -1,7 +1,7 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/require-field-of-type-query-in-mutation-result';
+import { rule } from '../src/rules/require-field-of-type-query-in-mutation-result';
 
-const useSchema = (code: string): { code: string; parserOptions: ParserOptions } => ({
+const useSchema = (code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => ({
   code,
   parserOptions: {
     schema: /* GraphQL */ `

--- a/packages/plugin/tests/require-id-when-available.spec.ts
+++ b/packages/plugin/tests/require-id-when-available.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule, { RequireIdWhenAvailableRuleConfig } from '../src/rules/require-id-when-available';
+import { rule, RequireIdWhenAvailableRuleConfig } from '../src/rules/require-id-when-available';
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {

--- a/packages/plugin/tests/selection-set-depth.spec.ts
+++ b/packages/plugin/tests/selection-set-depth.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule, { SelectionSetDepthRuleConfig } from '../src/rules/selection-set-depth';
+import { rule, SelectionSetDepthRuleConfig } from '../src/rules/selection-set-depth';
 
 const WITH_SIBLINGS = {
   parserOptions: <ParserOptions>{

--- a/packages/plugin/tests/strict-id-in-types.spec.ts
+++ b/packages/plugin/tests/strict-id-in-types.spec.ts
@@ -1,12 +1,12 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule, { StrictIdInTypesRuleConfig } from '../src/rules/strict-id-in-types';
+import { rule, StrictIdInTypesRuleConfig } from '../src/rules/strict-id-in-types';
 
 const ruleTester = new GraphQLRuleTester();
 
-function useSchema(code: string) {
+function useSchema(code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } {
   return {
     code,
-    parserOptions: <ParserOptions>{
+    parserOptions: {
       schema: code,
     },
   };

--- a/packages/plugin/tests/unique-fragment-name.spec.ts
+++ b/packages/plugin/tests/unique-fragment-name.spec.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/unique-fragment-name';
+import { rule } from '../src/rules/unique-fragment-name';
 
 const TEST_FRAGMENT = /* GraphQL */ `
   fragment HasIdFields on HasId {
@@ -8,8 +8,10 @@ const TEST_FRAGMENT = /* GraphQL */ `
   }
 `;
 
-const SIBLING_FRAGMENTS = (...operations: string[]) => ({
-  parserOptions: <ParserOptions>{
+const SIBLING_FRAGMENTS = (
+  ...operations: string[]
+): { parserOptions: Pick<ParserOptions, 'operations'> } => ({
+  parserOptions: {
     operations,
   },
 });

--- a/packages/plugin/tests/unique-operation-name.spec.ts
+++ b/packages/plugin/tests/unique-operation-name.spec.ts
@@ -1,11 +1,13 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
-import rule from '../src/rules/unique-operation-name';
+import { rule } from '../src/rules/unique-operation-name';
 import { join } from 'path';
 
 const TEST_OPERATION = 'query test { foo }';
 
-const SIBLING_OPERATIONS = (...operations: string[]) => ({
-  parserOptions: <ParserOptions>{
+const SIBLING_OPERATIONS = (
+  ...operations: string[]
+): { parserOptions: Pick<ParserOptions, 'operations'> } => ({
+  parserOptions: {
     operations,
   },
 });

--- a/packages/plugin/tests/unique-type-names.spec.ts
+++ b/packages/plugin/tests/unique-type-names.spec.ts
@@ -1,6 +1,5 @@
-import { GraphQLRuleTester } from '../src/testkit';
+import { GraphQLRuleTester, ParserOptions } from '../src';
 import { GRAPHQL_JS_VALIDATIONS } from '../src/rules/graphql-js-validation';
-import { ParserOptions } from '../src/types';
 
 const TEST_SCHEMA = /* GraphQL */ `
   type Query {

--- a/scripts/generate-configs.ts
+++ b/scripts/generate-configs.ts
@@ -46,7 +46,9 @@ const ruleFilenames = readdirSync(join(SRC_PATH, 'rules'))
 function generateRules(): void {
   const code = [
     "import { GRAPHQL_JS_VALIDATIONS } from './graphql-js-validation'",
-    ...ruleFilenames.map(ruleName => `import ${camelCase(ruleName)} from './${ruleName}'`),
+    ...ruleFilenames.map(
+      ruleName => `import { rule as ${camelCase(ruleName)} } from './${ruleName}'`,
+    ),
     BR,
     'export const rules = {',
     '...GRAPHQL_JS_VALIDATIONS,',


### PR DESCRIPTION
## Description

This change extends the `require-description` lint to require a description of operations. 

```graphql
# Correct
type Query {
  "Fetch users"
  users: [User!]!
}

# Incorrect
type Mutation {
  createUser(user: UserInput!): User!
}
```

The field definition within the operation types is tricky to target. A description isn't required for _every_ `Kind.FIELD_DEFINITION` so the existing feature would've involved excessive documentation. Since good code health could require documentation of usable operations, the lint was extended to target field definitions only within the scope of `Mutation`, `Query`, and `Subscription`.

This adds the boolean option `operationFieldDefinition` to `require-description` (default false).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

I added two valid unit tests and two invalid unit tests. They cover when an input is present and when an input is not present.

Both unit tests are within the `require-description.spec.ts` file

**Test Environment**:

- OS: Mac OS Monterrey
- `@graphql-eslint/...`: master?
- NodeJS: 18.3.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (_They add a new ESLint warning that's configurable and default disabled_)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (_N/A_)
