### PR TITLE
Simplify wording in rule docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 [known-directives](rules/known-directives.md)|A GraphQL document is only valid if all `@directive`s are known by the schema and legally positioned.|![recommended][]|🔮|
 [known-fragment-names](rules/known-fragment-names.md)|A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document.|![recommended][]|🔮|
 [known-type-names](rules/known-type-names.md)|A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.|![recommended][]|🔮|💡
-[lone-anonymous-operation](rules/lone-anonymous-operation.md)|A GraphQL document is only valid if when it contains an anonymous operation (the query short-hand) that it contains only that one operation definition.|![recommended][]|🔮|
+[lone-anonymous-operation](rules/lone-anonymous-operation.md)|A GraphQL document that contains an anonymous operation (the `query` short-hand) is only valid if it contains only that one operation definition.|![recommended][]|🔮|
 [lone-schema-definition](rules/lone-schema-definition.md)|A GraphQL document is only valid if it contains only one schema definition.|![recommended][]|🔮|
 [match-document-filename](rules/match-document-filename.md)|This rule allows you to enforce that the file name should match the operation name.|![all][]|🚀|
 [naming-convention](rules/naming-convention.md)|Require names to follow specified conventions.|![recommended][]|🚀|💡

--- a/docs/rules/lone-anonymous-operation.md
+++ b/docs/rules/lone-anonymous-operation.md
@@ -9,8 +9,8 @@ enables this rule.
 - Requires GraphQL Operations: `false`
   [ℹ️](../../README.md#extended-linting-rules-with-siblings-operations)
 
-A GraphQL document is only valid if when it contains an anonymous operation (the query short-hand)
-that it contains only that one operation definition.
+A GraphQL document that contains an anonymous operation (the `query` short-hand) is only valid if it
+contains only that one operation definition.
 
 > This rule is a wrapper around a `graphql-js` validation function.
 

--- a/packages/plugin/src/rules/graphql-js-validation.ts
+++ b/packages/plugin/src/rules/graphql-js-validation.ts
@@ -411,7 +411,7 @@ export const GRAPHQL_JS_VALIDATIONS: Record<string, GraphQLESLintRule> = Object.
     {
       category: 'Operations',
       description:
-        'A GraphQL document is only valid if when it contains an anonymous operation (the query short-hand) that it contains only that one operation definition.',
+        'A GraphQL document that contains an anonymous operation (the `query` short-hand) is only valid if it contains only that one operation definition.',
       requiresSchema: true,
     },
   ),


### PR DESCRIPTION
*Note: I deliberately ignored the PR description template, because this is a documentation-only change, and the template is not fitting here.*

The previous wording in the `lone-anonymous-operation` rule docs was difficult to understand. I simplified and clarified it.