### PR TITLE
Create new lone-executable-definition rule

### DIFF
--- a/.changeset/good-baboons-bathe.md
+++ b/.changeset/good-baboons-bathe.md
@@ -2,4 +2,5 @@
 '@graphql-eslint/eslint-plugin': minor
 ---
 
-[require-description] add `rootField` option for only field definitions within `Query`, `Mutation`, and `Subscription` root types
+[require-description] add `rootField` option for only field definitions within `Query`, `Mutation`,
+and `Subscription` root types

--- a/.changeset/strange-donuts-warn.md
+++ b/.changeset/strange-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+feat: add `lone-executable-definition` to tequire all queries, mutations, subscriptions and fragments to be located in separate files

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,5 @@ dist
 # TernJS port file
 .tern-port
 
-
 .bob/
 .idea/

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ -z "$husky_skip_init" ]; then
-  debug () {
+  debug() {
     [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## Available Rules
+# Available Rules
 
 Each rule has emojis denoting:
 
@@ -26,6 +26,7 @@ Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
 [known-fragment-names](rules/known-fragment-names.md)|A GraphQL document is only valid if all `...Fragment` fragment spreads refer to fragments defined in the same document.|![recommended][]|📦|🔮|
 [known-type-names](rules/known-type-names.md)|A GraphQL document is only valid if referenced types (specifically variable definitions and fragment conditions) are defined by the type schema.|![recommended][]|📄 📦|🔮|💡
 [lone-anonymous-operation](rules/lone-anonymous-operation.md)|A GraphQL document that contains an anonymous operation (the `query` short-hand) is only valid if it contains only that one operation definition.|![recommended][]|📦|🔮|
+[lone-executable-definition](rules/lone-executable-definition.md)|Require all queries, mutations, subscriptions and fragments to be located in separate files.|![all][]|📦|🚀|
 [lone-schema-definition](rules/lone-schema-definition.md)|A GraphQL document is only valid if it contains only one schema definition.|![recommended][]|📄|🔮|
 [match-document-filename](rules/match-document-filename.md)|This rule allows you to enforce that the file name should match the operation name.|![all][]|📦|🚀|
 [naming-convention](rules/naming-convention.md)|Require names to follow specified conventions.|![recommended][]|📄 📦|🚀|💡

--- a/docs/rules/lone-executable-definition.md
+++ b/docs/rules/lone-executable-definition.md
@@ -37,14 +37,14 @@ query Foo {
 
 The schema defines the following properties:
 
-### `ignores` (array)
+### `ignore` (array)
 
 Allow certain definitions to be placed alongside others.
 
 The elements of the array can contain the following enum values:
 
-- `query`
 - `fragment`
+- `query`
 - `mutation`
 - `subscription`
 

--- a/docs/rules/lone-executable-definition.md
+++ b/docs/rules/lone-executable-definition.md
@@ -1,0 +1,59 @@
+# `lone-executable-definition`
+
+- Category: `Operations`
+- Rule name: `@graphql-eslint/lone-executable-definition`
+- Requires GraphQL Schema: `false` [ℹ️](../../README.md#extended-linting-rules-with-graphql-schema)
+- Requires GraphQL Operations: `false`
+  [ℹ️](../../README.md#extended-linting-rules-with-siblings-operations)
+
+Require all queries, mutations, subscriptions and fragments to be located in separate files.
+
+## Usage Examples
+
+### Incorrect
+
+```graphql
+# eslint @graphql-eslint/lone-executable-definition: 'error'
+
+query Foo {
+  id
+}
+fragment Bar on Baz {
+  id
+}
+```
+
+### Correct
+
+```graphql
+# eslint @graphql-eslint/lone-executable-definition: 'error'
+
+query Foo {
+  id
+}
+```
+
+## Config Schema
+
+The schema defines the following properties:
+
+### `ignores` (array)
+
+Allow certain definitions to be placed alongside others.
+
+The elements of the array can contain the following enum values:
+
+- `query`
+- `fragment`
+- `mutation`
+- `subscription`
+
+Additional restrictions:
+
+- Minimum items: `1`
+- Unique items: `true`
+
+## Resources
+
+- [Rule source](../../packages/plugin/src/rules/lone-executable-definition.ts)
+- [Test source](../../packages/plugin/tests/lone-executable-definition.spec.ts)

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -82,7 +82,7 @@ Includes:
 
 ### `rootField` (boolean)
 
-Definitions within `Query`, `Mutation`, and `Subscription` root types
+Definitions within `Query`, `Mutation`, and `Subscription` root types.
 
 ### `DirectiveDefinition` (boolean)
 

--- a/packages/plugin/src/configs/operations-all.json
+++ b/packages/plugin/src/configs/operations-all.json
@@ -9,6 +9,7 @@
         "arguments": ["Field", "Directive"]
       }
     ],
+    "@graphql-eslint/lone-executable-definition": "error",
     "@graphql-eslint/match-document-filename": [
       "error",
       {

--- a/packages/plugin/src/rules/index.ts
+++ b/packages/plugin/src/rules/index.ts
@@ -37,6 +37,7 @@ export const rules = {
   alphabetize,
   'description-style': descriptionStyle,
   'input-name': inputName,
+  'lone-executable-definition': loneExecutableDefinition,
   'match-document-filename': matchDocumentFilename,
   'naming-convention': namingConvention,
   'no-anonymous-operations': noAnonymousOperations,

--- a/packages/plugin/src/rules/index.ts
+++ b/packages/plugin/src/rules/index.ts
@@ -6,6 +6,7 @@ import { GRAPHQL_JS_VALIDATIONS } from './graphql-js-validation';
 import { rule as alphabetize } from './alphabetize';
 import { rule as descriptionStyle } from './description-style';
 import { rule as inputName } from './input-name';
+import { rule as loneExecutableDefinition } from './lone-executable-definition';
 import { rule as matchDocumentFilename } from './match-document-filename';
 import { rule as namingConvention } from './naming-convention';
 import { rule as noAnonymousOperations } from './no-anonymous-operations';

--- a/packages/plugin/src/rules/lone-executable-definition.ts
+++ b/packages/plugin/src/rules/lone-executable-definition.ts
@@ -10,7 +10,7 @@ type Definition = 'fragment' | 'query' | 'mutation' | 'subscription';
 const types: Definition[] = ['fragment', 'query', 'mutation', 'subscription'];
 
 export interface LoneExecutableDefinitionConfig {
-  ignore?: typeof types[number][];
+  ignore?: typeof types;
 }
 
 type DefinitionESTreeNode = GraphQLESTreeNode<ExecutableDefinitionNode>;

--- a/packages/plugin/src/rules/lone-executable-definition.ts
+++ b/packages/plugin/src/rules/lone-executable-definition.ts
@@ -1,18 +1,13 @@
 import { GraphQLESLintRule } from '../types';
-import { ExecutableDefinitionNode, OperationTypeNode } from 'graphql';
+import { ExecutableDefinitionNode } from 'graphql';
 import { GraphQLESTreeNode } from '../estree-converter';
 import { ARRAY_DEFAULT_OPTIONS, pascalCase, getLocation } from '../utils';
 
 const RULE_ID = 'lone-executable-definition';
 
-type Definition = 'fragment' | OperationTypeNode;
+type Definition = 'fragment' | 'query' | 'mutation' | 'subscription';
 
-const types: Definition[] = [
-  'fragment',
-  OperationTypeNode.QUERY,
-  OperationTypeNode.MUTATION,
-  OperationTypeNode.SUBSCRIPTION,
-];
+const types: Definition[] = ['fragment', 'query', 'mutation', 'subscription'];
 
 export interface LoneExecutableDefinitionConfig {
   ignore?: typeof types[number][];

--- a/packages/plugin/src/rules/lone-executable-definition.ts
+++ b/packages/plugin/src/rules/lone-executable-definition.ts
@@ -1,0 +1,111 @@
+import { GraphQLESLintRule } from '../types';
+import { OperationDefinitionNode, FragmentDefinitionNode, Kind } from 'graphql';
+import { GraphQLESTreeNode } from '../estree-converter';
+import { ARRAY_DEFAULT_OPTIONS } from '../utils';
+
+const RULE_ID = 'lone-executable-definition';
+const definitionsEnum = [
+  'query' as const,
+  'fragment' as const,
+  'mutation' as const,
+  'subscription' as const,
+];
+
+export interface LoneExecutableDefinitionConfig {
+  ignore?: typeof definitionsEnum[number][];
+}
+
+type DefinitionESTreeNode =
+  | GraphQLESTreeNode<OperationDefinitionNode>
+  | GraphQLESTreeNode<FragmentDefinitionNode>;
+
+const uppercaseFirst = (string: string) => string.slice(0, 1).toUpperCase() + string.slice(1);
+
+const isDefinitionNode = (node: { kind: string }): node is DefinitionESTreeNode =>
+  node.kind === Kind.OPERATION_DEFINITION || node.kind === Kind.FRAGMENT_DEFINITION;
+
+const rule: GraphQLESLintRule<[LoneExecutableDefinitionConfig]> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      category: 'Operations',
+      description:
+        'Require all queries, mutations, subscriptions and fragments to be located in separate files.',
+      url: `https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/${RULE_ID}.md`,
+      examples: [
+        {
+          title: 'Incorrect',
+          code: /* GraphQL */ `
+            query Foo {
+              id
+            }
+            fragment Bar on Baz {
+              id
+            }
+          `,
+        },
+        {
+          title: 'Correct',
+          code: /* GraphQL */ `
+            query Foo {
+              id
+            }
+          `,
+        },
+      ],
+    },
+    messages: {
+      [RULE_ID]: '{{name}} should be in a separate file.',
+    },
+    schema: {
+      type: 'array',
+      minItems: 0,
+      maxItems: 1,
+      items: {
+        type: 'object',
+        minProperties: 1,
+        properties: {
+          ignores: {
+            ...ARRAY_DEFAULT_OPTIONS,
+            items: {
+              enum: definitionsEnum,
+            },
+            description: 'Allow certain definitions to be placed alongside others.',
+          },
+        },
+      },
+    },
+  },
+  create(context) {
+    const ignore = new Set(context.options[0]?.ignore ?? []);
+
+    return {
+      Document(node) {
+        const definitions = node.definitions
+          .slice(1) // ignore first definition
+          .filter(isDefinitionNode)
+          .map(node => ({
+            node,
+            type: 'operation' in node ? node.operation : ('fragment' as const),
+          }))
+          .filter(({ type }) => !ignore.has(type));
+
+        for (const { node, type } of definitions) {
+          const typeName = uppercaseFirst(type);
+          const definitionName = node.name?.value;
+          const name = definitionName ? `${typeName} "${definitionName}"` : typeName;
+
+          context.report({
+            node,
+            messageId: RULE_ID,
+            data: {
+              name,
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/plugin/src/rules/lone-executable-definition.ts
+++ b/packages/plugin/src/rules/lone-executable-definition.ts
@@ -82,13 +82,13 @@ const rule: GraphQLESLintRule<[LoneExecutableDefinitionConfig]> = {
     return {
       Document(node) {
         const definitions = node.definitions
-          .slice(1) // ignore first definition
           .filter(isDefinitionNode)
           .map(node => ({
             node,
             type: 'operation' in node ? node.operation : ('fragment' as const),
           }))
-          .filter(({ type }) => !ignore.has(type));
+          .filter(({ type }) => !ignore.has(type))
+          .slice(1); // ignore first definition
 
         for (const { node, type } of definitions) {
           const typeName = uppercaseFirst(type);

--- a/packages/plugin/src/rules/require-description.ts
+++ b/packages/plugin/src/rules/require-description.ts
@@ -140,7 +140,7 @@ export const rule: GraphQLESLintRule<[RequireDescriptionRuleConfig]> = {
           },
           rootField: {
             type: 'boolean',
-            description: 'Definitions within `Query`, `Mutation`, and `Subscription` root types',
+            description: 'Definitions within `Query`, `Mutation`, and `Subscription` root types.',
           },
           ...Object.fromEntries(
             [...ALLOWED_KINDS].sort().map(kind => {

--- a/packages/plugin/src/utils.ts
+++ b/packages/plugin/src/utils.ts
@@ -61,7 +61,7 @@ export const TYPES_KINDS = [
 
 export type CaseStyle = 'camelCase' | 'PascalCase' | 'snake_case' | 'UPPER_CASE' | 'kebab-case';
 
-const pascalCase = (str: string): string =>
+export const pascalCase = (str: string): string =>
   lowerCase(str)
     .split(' ')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/packages/plugin/tests/__snapshots__/lone-executable-definition.spec.md
+++ b/packages/plugin/tests/__snapshots__/lone-executable-definition.spec.md
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should allow fragments if they are ignored 1`] = `
+#### ⌨️ Code
+
+       1 |         query Foo {
+       2 |           id
+       3 |         }
+       4 |         fragment Bar on Bar {
+       5 |           id
+       6 |         }
+       7 |         mutation Baz($name: String!) {
+       8 |           createFoo {
+       9 |             name
+      10 |           }
+      11 |         }
+
+#### ⚙️ Options
+
+    {
+      "ignore": [
+        "fragment"
+      ]
+    }
+
+#### ❌ Error
+
+       6 |         }
+    >  7 |         mutation Baz($name: String!) {
+         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    >  8 |           createFoo {
+         | ^^^^^^^^^^^^^^^^^^^^^
+    >  9 |             name
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 10 |           }
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 11 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation "Baz" should be in a separate file.
+`;
+
+exports[`should report additional definitions 1`] = `
+#### ⌨️ Code
+
+       1 |         query Valid {
+       2 |           id
+       3 |         }
+       4 |         query Foo {
+       5 |           id
+       6 |         }
+       7 |         fragment Bar on Bar {
+       8 |           id
+       9 |         }
+      10 |         mutation ($name: String!) {
+      11 |           createFoo {
+      12 |             name
+      13 |           }
+      14 |         }
+      15 |         mutation Baz($name: String!) {
+      16 |           createFoo {
+      17 |             name
+      18 |           }
+      19 |         }
+      20 |         subscription {
+      21 |           id
+      22 |         }
+      23 |         subscription Sub {
+      24 |           id
+      25 |         }
+
+#### ❌ Error 1/6
+
+      3 |         }
+    > 4 |         query Foo {
+        |         ^^^^^^^^^^^
+    > 5 |           id
+        | ^^^^^^^^^^^^
+    > 6 |         }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Query "Foo" should be in a separate file.
+      7 |         fragment Bar on Bar {
+
+#### ❌ Error 2/6
+
+       6 |         }
+    >  7 |         fragment Bar on Bar {
+         |         ^^^^^^^^^^^^^^^^^^^^^
+    >  8 |           id
+         | ^^^^^^^^^^^^
+    >  9 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment "Bar" should be in a separate file.
+      10 |         mutation ($name: String!) {
+
+#### ❌ Error 3/6
+
+       9 |         }
+    > 10 |         mutation ($name: String!) {
+         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    > 11 |           createFoo {
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 12 |             name
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 13 |           }
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 14 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation should be in a separate file.
+      15 |         mutation Baz($name: String!) {
+
+#### ❌ Error 4/6
+
+      14 |         }
+    > 15 |         mutation Baz($name: String!) {
+         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    > 16 |           createFoo {
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 17 |             name
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 18 |           }
+         | ^^^^^^^^^^^^^^^^^^^^^
+    > 19 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation "Baz" should be in a separate file.
+      20 |         subscription {
+
+#### ❌ Error 5/6
+
+      19 |         }
+    > 20 |         subscription {
+         |         ^^^^^^^^^^^^^^
+    > 21 |           id
+         | ^^^^^^^^^^^^
+    > 22 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Subscription should be in a separate file.
+      23 |         subscription Sub {
+
+#### ❌ Error 6/6
+
+      22 |         }
+    > 23 |         subscription Sub {
+         |         ^^^^^^^^^^^^^^^^^^
+    > 24 |           id
+         | ^^^^^^^^^^^^
+    > 25 |         }
+         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Subscription "Sub" should be in a separate file.
+`;
+
+exports[`should report definitions after short-hand query 1`] = `
+#### ⌨️ Code
+
+      1 |         {
+      2 |           id
+      3 |         }
+      4 |         fragment Bar on Bar {
+      5 |           id
+      6 |         }
+
+#### ❌ Error
+
+      3 |         }
+    > 4 |         fragment Bar on Bar {
+        |         ^^^^^^^^^^^^^^^^^^^^^
+    > 5 |           id
+        | ^^^^^^^^^^^^
+    > 6 |         }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment "Bar" should be in a separate file.
+`;

--- a/packages/plugin/tests/__snapshots__/lone-executable-definition.spec.md
+++ b/packages/plugin/tests/__snapshots__/lone-executable-definition.spec.md
@@ -25,17 +25,10 @@ exports[`should allow fragments if they are ignored 1`] = `
 
 #### ❌ Error
 
-       6 |         }
-    >  7 |         mutation Baz($name: String!) {
-         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    >  8 |           createFoo {
-         | ^^^^^^^^^^^^^^^^^^^^^
-    >  9 |             name
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 10 |           }
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 11 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation "Baz" should be in a separate file.
+      6 |         }
+    > 7 |         mutation Baz($name: String!) {
+        |                  ^^^ Mutation "Baz" should be in a separate file.
+      8 |           createFoo {
 `;
 
 exports[`should report additional definitions 1`] = `
@@ -44,7 +37,7 @@ exports[`should report additional definitions 1`] = `
        1 |         query Valid {
        2 |           id
        3 |         }
-       4 |         query Foo {
+       4 |         {
        5 |           id
        6 |         }
        7 |         fragment Bar on Bar {
@@ -70,75 +63,44 @@ exports[`should report additional definitions 1`] = `
 #### ❌ Error 1/6
 
       3 |         }
-    > 4 |         query Foo {
-        |         ^^^^^^^^^^^
-    > 5 |           id
-        | ^^^^^^^^^^^^
-    > 6 |         }
-        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Query "Foo" should be in a separate file.
-      7 |         fragment Bar on Bar {
+    > 4 |         {
+        |         ^^^^^ Query should be in a separate file.
+      5 |           id
 
 #### ❌ Error 2/6
 
-       6 |         }
-    >  7 |         fragment Bar on Bar {
-         |         ^^^^^^^^^^^^^^^^^^^^^
-    >  8 |           id
-         | ^^^^^^^^^^^^
-    >  9 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment "Bar" should be in a separate file.
-      10 |         mutation ($name: String!) {
+      6 |         }
+    > 7 |         fragment Bar on Bar {
+        |                  ^^^ Fragment "Bar" should be in a separate file.
+      8 |           id
 
 #### ❌ Error 3/6
 
        9 |         }
     > 10 |         mutation ($name: String!) {
-         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    > 11 |           createFoo {
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 12 |             name
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 13 |           }
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 14 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation should be in a separate file.
-      15 |         mutation Baz($name: String!) {
+         |         ^^^^^^^^ Mutation should be in a separate file.
+      11 |           createFoo {
 
 #### ❌ Error 4/6
 
       14 |         }
     > 15 |         mutation Baz($name: String!) {
-         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    > 16 |           createFoo {
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 17 |             name
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 18 |           }
-         | ^^^^^^^^^^^^^^^^^^^^^
-    > 19 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mutation "Baz" should be in a separate file.
-      20 |         subscription {
+         |                  ^^^ Mutation "Baz" should be in a separate file.
+      16 |           createFoo {
 
 #### ❌ Error 5/6
 
       19 |         }
     > 20 |         subscription {
-         |         ^^^^^^^^^^^^^^
-    > 21 |           id
-         | ^^^^^^^^^^^^
-    > 22 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Subscription should be in a separate file.
-      23 |         subscription Sub {
+         |         ^^^^^^^^^^^^ Subscription should be in a separate file.
+      21 |           id
 
 #### ❌ Error 6/6
 
       22 |         }
     > 23 |         subscription Sub {
-         |         ^^^^^^^^^^^^^^^^^^
-    > 24 |           id
-         | ^^^^^^^^^^^^
-    > 25 |         }
-         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Subscription "Sub" should be in a separate file.
+         |                      ^^^ Subscription "Sub" should be in a separate file.
+      24 |           id
 `;
 
 exports[`should report definitions after short-hand query 1`] = `
@@ -155,9 +117,6 @@ exports[`should report definitions after short-hand query 1`] = `
 
       3 |         }
     > 4 |         fragment Bar on Bar {
-        |         ^^^^^^^^^^^^^^^^^^^^^
-    > 5 |           id
-        | ^^^^^^^^^^^^
-    > 6 |         }
-        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fragment "Bar" should be in a separate file.
+        |                  ^^^ Fragment "Bar" should be in a separate file.
+      5 |           id
 `;

--- a/packages/plugin/tests/lone-executable-definition.spec.ts
+++ b/packages/plugin/tests/lone-executable-definition.spec.ts
@@ -1,0 +1,159 @@
+import { GraphQLRuleTester } from '../src';
+import rule from '../src/rules/lone-executable-definition';
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests('lone-executable-definition', rule, {
+  valid: [
+    {
+      name: 'should allow single short-hand query',
+      code: /* GraphQL */ `
+        {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow single anonymous query',
+      code: /* GraphQL */ `
+        query {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow single named query',
+      code: /* GraphQL */ `
+        query Foo {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow single fragment',
+      code: /* GraphQL */ `
+        fragment Foo on Bar {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow single anonymous mutation',
+      code: /* GraphQL */ `
+        mutation ($name: String!) {
+          createFoo {
+            name
+          }
+        }
+      `,
+    },
+    {
+      name: 'should allow single named mutation',
+      code: /* GraphQL */ `
+        mutation Foo($name: String!) {
+          createFoo {
+            name
+          }
+        }
+      `,
+    },
+    {
+      name: 'should allow single anonymous subscription',
+      code: /* GraphQL */ `
+        subscription {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow single named subscription',
+      code: /* GraphQL */ `
+        subscription Foo {
+          id
+        }
+      `,
+    },
+    {
+      name: 'should allow fragments if they are ignored',
+      options: [{ ignore: ['fragment'] }],
+      code: /* GraphQL */ `
+        {
+          id
+        }
+        fragment Bar on Bar {
+          id
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'should report additional definitions',
+      code: /* GraphQL */ `
+        query Valid {
+          id
+        }
+        query Foo {
+          id
+        }
+        fragment Bar on Bar {
+          id
+        }
+        mutation ($name: String!) {
+          createFoo {
+            name
+          }
+        }
+        mutation Baz($name: String!) {
+          createFoo {
+            name
+          }
+        }
+        subscription {
+          id
+        }
+        subscription Sub {
+          id
+        }
+      `,
+      errors: [
+        { message: 'Query "Foo" should be in a separate file.' },
+        { message: 'Fragment "Bar" should be in a separate file.' },
+        { message: 'Mutation should be in a separate file.' },
+        { message: 'Mutation "Baz" should be in a separate file.' },
+        { message: 'Subscription should be in a separate file.' },
+        { message: 'Subscription "Sub" should be in a separate file.' },
+      ],
+    },
+    {
+      name: 'should report definitions after short-hand query',
+      code: /* GraphQL */ `
+        {
+          id
+        }
+        fragment Bar on Bar {
+          id
+        }
+      `,
+      errors: [{ message: 'Fragment "Bar" should be in a separate file.' }],
+    },
+    {
+      name: 'should allow fragments if they are ignored',
+      options: [{ ignore: ['fragment'] }],
+      code: /* GraphQL */ `
+        query Foo {
+          id
+        }
+        fragment Bar on Bar {
+          id
+        }
+        mutation Baz($name: String!) {
+          createFoo {
+            name
+          }
+        }
+      `,
+      errors: [{ message: 'Mutation "Baz" should be in a separate file.' }],
+    },
+  ],
+});

--- a/packages/plugin/tests/lone-executable-definition.spec.ts
+++ b/packages/plugin/tests/lone-executable-definition.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLRuleTester } from '../src';
-import rule from '../src/rules/lone-executable-definition';
+import { rule } from '../src/rules/lone-executable-definition';
 
 const ruleTester = new GraphQLRuleTester();
 
@@ -105,7 +105,7 @@ ruleTester.runGraphQLTests('lone-executable-definition', rule, {
         query Valid {
           id
         }
-        query Foo {
+        {
           id
         }
         fragment Bar on Bar {
@@ -129,7 +129,7 @@ ruleTester.runGraphQLTests('lone-executable-definition', rule, {
         }
       `,
       errors: [
-        { message: 'Query "Foo" should be in a separate file.' },
+        { message: 'Query should be in a separate file.' },
         { message: 'Fragment "Bar" should be in a separate file.' },
         { message: 'Mutation should be in a separate file.' },
         { message: 'Mutation "Baz" should be in a separate file.' },

--- a/packages/plugin/tests/lone-executable-definition.spec.ts
+++ b/packages/plugin/tests/lone-executable-definition.spec.ts
@@ -85,6 +85,18 @@ ruleTester.runGraphQLTests('lone-executable-definition', rule, {
         }
       `,
     },
+    {
+      name: 'should ignore definitions even if they are first in the document',
+      options: [{ ignore: ['fragment'] }],
+      code: /* GraphQL */ `
+        fragment Bar on Bar {
+          id
+        }
+        query Foo {
+          id
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/plugin/tests/no-unreachable-types.spec.ts
+++ b/packages/plugin/tests/no-unreachable-types.spec.ts
@@ -1,7 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
 import { rule } from '../src/rules/no-unreachable-types';
 
-const useSchema = (schema: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => {
+const useSchema = (
+  schema: string,
+): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => {
   return {
     parserOptions: { schema },
     code: schema,

--- a/packages/plugin/tests/possible-type-extension.spec.ts
+++ b/packages/plugin/tests/possible-type-extension.spec.ts
@@ -3,7 +3,9 @@ import { GraphQLRuleTester, rules, ParserOptions } from '../src';
 
 const ruleTester = new GraphQLRuleTester();
 
-const useUserSchema = (code: string): { code: string, parserOptions: Pick<ParserOptions, 'schema'> } => {
+const useUserSchema = (
+  code: string,
+): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => {
   return {
     code,
     parserOptions: {

--- a/packages/plugin/tests/require-field-of-type-query-in-mutation-result.spec.ts
+++ b/packages/plugin/tests/require-field-of-type-query-in-mutation-result.spec.ts
@@ -1,7 +1,9 @@
 import { GraphQLRuleTester, ParserOptions } from '../src';
 import { rule } from '../src/rules/require-field-of-type-query-in-mutation-result';
 
-const useSchema = (code: string): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => ({
+const useSchema = (
+  code: string,
+): { code: string; parserOptions: Pick<ParserOptions, 'schema'> } => ({
   code,
   parserOptions: {
     schema: /* GraphQL */ `

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -181,7 +181,7 @@ async function generateDocs(): Promise<void> {
   result.push({
     path: resolve(DOCS_PATH, 'README.md'),
     content: [
-      '## Available Rules',
+      '# Available Rules',
       'Each rule has emojis denoting:',
       `- ${Icon.SCHEMA} if the rule applies to schema documents`,
       `- ${Icon.OPERATIONS} if the rule applies to operations`,


### PR DESCRIPTION
## Description

Adds the suggested rule from #1311 to require one file per query/fragment/mutation/subscription. Fixes #1311.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've created new unit tests for the rule, and also ran `npm test` to be sure that I did not break anything.

**Test Environment**:

- OS: Ubuntu 22.04
- NodeJS: 16.18.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The latest commit (b0b0cc802ea5d66da3d1939416df81b08284d6d2) were automatically generated with `npm run prettier`. I'm happy to revert it if required.