### PR TITLE
DRY in `lone-executable-definition` rule

### DIFF
--- a/packages/plugin/src/rules/lone-executable-definition.ts
+++ b/packages/plugin/src/rules/lone-executable-definition.ts
@@ -6,8 +6,9 @@ import { FromSchema } from 'json-schema-to-ts';
 
 const RULE_ID = 'lone-executable-definition';
 
-type Definition = 'fragment' | 'query' | 'mutation' | 'subscription';
+const definitionTypes = ['fragment', 'query', 'mutation', 'subscription'] as const;
 
+type Definition = (typeof definitionTypes)[number];
 type DefinitionESTreeNode = GraphQLESTreeNode<ExecutableDefinitionNode>;
 
 const schema = {
@@ -22,7 +23,7 @@ const schema = {
         ...ARRAY_DEFAULT_OPTIONS,
         maxItems: 3, // ignore all 4 types is redundant
         items: {
-          enum: ['fragment', 'query', 'mutation', 'subscription'],
+          enum: definitionTypes,
         },
         description: 'Allow certain definitions to be placed alongside others.',
       },


### PR DESCRIPTION
Follow-up to #1316 and #1319. This is a small refactoring to avoid repeating the same GraphQL definition types in the `type` and the schema definition.