### PR TITLE
Add `requiredPrefixes` and `requiredSuffixes` to `naming-convention`

### DIFF
--- a/.changeset/green-vans-leave.md
+++ b/.changeset/green-vans-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': minor
+---
+
+[naming-convention]: add new options `requiredPrefixes`, `requiredSuffixes`

--- a/packages/plugin/src/rules/naming-convention.ts
+++ b/packages/plugin/src/rules/naming-convention.ts
@@ -290,6 +290,46 @@ export const rule: GraphQLESLintRule<RuleOptions> = {
             }
           `,
         },
+        {
+          title: 'Correct',
+          usage: [
+            {
+              'FieldDefinition[gqlType.name.value=Boolean]': {
+                style: 'camelCase',
+                requiredPrefixes: ['is', 'has'],
+              },
+              'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+                style: 'camelCase',
+                requiredPrefixes: ['is', 'has'],
+              },
+            },
+          ],
+          code: /* GraphQL */ `
+            type Product {
+              isBackordered: Boolean
+              isNew: Boolean!
+              hasDiscount: Boolean!
+            }
+          `,
+        },
+        {
+          title: 'Correct',
+          usage: [
+            {
+              'FieldDefinition[gqlType.gqlType.name.value=SensitiveSecret]': {
+                style: 'camelCase',
+                requiredSuffixes: ['SensitiveSecret'],
+              },
+            },
+          ],
+          code: /* GraphQL */ `
+            scalar SensitiveSecret
+
+            type Account {
+              accountSensitiveSecret: SensitiveSecret!
+            }
+          `,
+        },
       ],
       configOptions: {
         schema: [

--- a/packages/plugin/tests/__snapshots__/naming-convention.spec.md
+++ b/packages/plugin/tests/__snapshots__/naming-convention.spec.md
@@ -2212,7 +2212,7 @@ exports[`should error when selected type names do not match require prefixes 1`]
 
       7 |         type Test {
     > 8 |           enabled: Boolean!
-        |           ^^^^^^^ Field "enabled" should have one of the following prefixes: is, or has
+        |           ^^^^^^^ Field "enabled" should have one of the following prefixes: is or has
       9 |           secret: Secret!
 
 #### 💡 Suggestion 1/2: Rename to \`isEnabled\`
@@ -2317,7 +2317,7 @@ exports[`should error when selected type names do not match require suffixes 1`]
 
       3 |         type Test {
     > 4 |           specialFeature: Boolean!
-        |           ^^^^^^^^^^^^^^ Field "specialFeature" should have one of the following suffixes: Enabled, or Disabled
+        |           ^^^^^^^^^^^^^^ Field "specialFeature" should have one of the following suffixes: Enabled or Disabled
       5 |           user: IpAddress!
 
 #### 💡 Suggestion 1/2: Rename to \`specialFeatureEnabled\`

--- a/packages/plugin/tests/__snapshots__/naming-convention.spec.md
+++ b/packages/plugin/tests/__snapshots__/naming-convention.spec.md
@@ -2170,7 +2170,7 @@ exports[`schema-recommended config 1`] = `
     15 |         }
 `;
 
-exports[`should error when selected types do not match require prefixes 1`] = `
+exports[`should error when selected type names do not match require prefixes 1`] = `
 #### ⌨️ Code
 
        1 |         scalar Secret
@@ -2284,6 +2284,75 @@ exports[`should error when selected types do not match require prefixes 1`] = `
      9 |           secret: Secret!
     10 |           hiss_snake: Snake
     11 |         }
+`;
+
+exports[`should error when selected type names do not match require suffixes 1`] = `
+#### ⌨️ Code
+
+      1 |         scalar IpAddress
+      2 |
+      3 |         type Test {
+      4 |           specialFeature: Boolean!
+      5 |           user: IpAddress!
+      6 |         }
+
+#### ⚙️ Options
+
+    {
+      "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+        "style": "camelCase",
+        "requiredSuffixes": [
+          "Enabled",
+          "Disabled"
+        ]
+      },
+      "FieldDefinition[gqlType.gqlType.name.value=IpAddress]": {
+        "requiredSuffixes": [
+          "IpAddress"
+        ]
+      }
+    }
+
+#### ❌ Error 1/2
+
+      3 |         type Test {
+    > 4 |           specialFeature: Boolean!
+        |           ^^^^^^^^^^^^^^ Field "specialFeature" should have one of the following suffixes: Enabled, or Disabled
+      5 |           user: IpAddress!
+
+#### 💡 Suggestion 1/2: Rename to \`specialFeatureEnabled\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeatureEnabled: Boolean!
+    5 |           user: IpAddress!
+    6 |         }
+
+#### 💡 Suggestion 2/2: Rename to \`specialFeatureDisabled\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeatureDisabled: Boolean!
+    5 |           user: IpAddress!
+    6 |         }
+
+#### ❌ Error 2/2
+
+      4 |           specialFeature: Boolean!
+    > 5 |           user: IpAddress!
+        |           ^^^^ Field "user" should have one of the following suffixes: IpAddress
+      6 |         }
+
+#### 💡 Suggestion: Rename to \`userIpAddress\`
+
+    1 |         scalar IpAddress
+    2 |
+    3 |         type Test {
+    4 |           specialFeature: Boolean!
+    5 |           userIpAddress: IpAddress!
+    6 |         }
 `;
 
 exports[`should ignore selections fields but check alias renaming 1`] = `

--- a/packages/plugin/tests/__snapshots__/naming-convention.spec.md
+++ b/packages/plugin/tests/__snapshots__/naming-convention.spec.md
@@ -2170,6 +2170,122 @@ exports[`schema-recommended config 1`] = `
     15 |         }
 `;
 
+exports[`should error when selected types do not match require prefixes 1`] = `
+#### ⌨️ Code
+
+       1 |         scalar Secret
+       2 |
+       3 |         interface Snake {
+       4 |           value: String!
+       5 |         }
+       6 |
+       7 |         type Test {
+       8 |           enabled: Boolean!
+       9 |           secret: Secret!
+      10 |           snake: Snake
+      11 |         }
+
+#### ⚙️ Options
+
+    {
+      "FieldDefinition[gqlType.gqlType.name.value=Boolean]": {
+        "style": "camelCase",
+        "requiredPrefixes": [
+          "is",
+          "has"
+        ]
+      },
+      "FieldDefinition[gqlType.gqlType.name.value=Secret]": {
+        "requiredPrefixes": [
+          "SUPER_SECRET_"
+        ]
+      },
+      "FieldDefinition[gqlType.name.value=Snake]": {
+        "style": "snake_case",
+        "requiredPrefixes": [
+          "hiss"
+        ]
+      }
+    }
+
+#### ❌ Error 1/3
+
+      7 |         type Test {
+    > 8 |           enabled: Boolean!
+        |           ^^^^^^^ Field "enabled" should have one of the following prefixes: is, or has
+      9 |           secret: Secret!
+
+#### 💡 Suggestion 1/2: Rename to \`isEnabled\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           isEnabled: Boolean!
+     9 |           secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### 💡 Suggestion 2/2: Rename to \`hasEnabled\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           hasEnabled: Boolean!
+     9 |           secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### ❌ Error 2/3
+
+       8 |           enabled: Boolean!
+    >  9 |           secret: Secret!
+         |           ^^^^^^ Field "secret" should have one of the following prefixes: SUPER_SECRET_
+      10 |           snake: Snake
+
+#### 💡 Suggestion: Rename to \`SUPER_SECRET_secret\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           enabled: Boolean!
+     9 |           SUPER_SECRET_secret: Secret!
+    10 |           snake: Snake
+    11 |         }
+
+#### ❌ Error 3/3
+
+       9 |           secret: Secret!
+    > 10 |           snake: Snake
+         |           ^^^^^ Field "snake" should have one of the following prefixes: hiss
+      11 |         }
+
+#### 💡 Suggestion: Rename to \`hiss_snake\`
+
+     1 |         scalar Secret
+     2 |
+     3 |         interface Snake {
+     4 |           value: String!
+     5 |         }
+     6 |
+     7 |         type Test {
+     8 |           enabled: Boolean!
+     9 |           secret: Secret!
+    10 |           hiss_snake: Snake
+    11 |         }
+`;
+
 exports[`should ignore selections fields but check alias renaming 1`] = `
 #### ⌨️ Code
 

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -160,6 +160,36 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
       code: 'type T',
       options: [{ ObjectTypeDefinition: 'UPPER_CASE' }],
     },
+    {
+      options: [
+        {
+          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+            style: 'camelCase',
+            requiredPrefixes: ['is', 'has'],
+          },
+          'FieldDefinition[gqlType.gqlType.name.value=Secret]': {
+            requiredPrefixes: ['SUPER_SECRET_'],
+          },
+          'FieldDefinition[gqlType.name.value=Snake]': {
+            style: 'snake_case',
+            requiredPrefixes: ['hiss'],
+          },
+        },
+      ],
+      code: /* GraphQL */ `
+        scalar Secret
+
+        interface Snake {
+          value: String!
+        }
+
+        type Test {
+          isEnabled: Boolean!
+          SUPER_SECRET_secret: Secret!
+          hiss_snake: Snake
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -402,6 +432,42 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
       errors: [
         { message: 'Leading underscores are not allowed' },
         { message: 'Trailing underscores are not allowed' },
+      ],
+    },
+    {
+      name: 'should error when selected types do not match require prefixes',
+      options: [
+        {
+          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+            style: 'camelCase',
+            requiredPrefixes: ['is', 'has'],
+          },
+          'FieldDefinition[gqlType.gqlType.name.value=Secret]': {
+            requiredPrefixes: ['SUPER_SECRET_'],
+          },
+          'FieldDefinition[gqlType.name.value=Snake]': {
+            style: 'snake_case',
+            requiredPrefixes: ['hiss'],
+          },
+        },
+      ],
+      code: /* GraphQL */ `
+        scalar Secret
+
+        interface Snake {
+          value: String!
+        }
+
+        type Test {
+          enabled: Boolean!
+          secret: Secret!
+          snake: Snake
+        }
+      `,
+      errors: [
+        { message: 'Field "enabled" should have one of the following prefixes: is, or has' },
+        { message: 'Field "secret" should have one of the following prefixes: SUPER_SECRET_' },
+        { message: 'Field "snake" should have one of the following prefixes: hiss' },
       ],
     },
   ],

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -161,21 +161,6 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
       options: [{ ObjectTypeDefinition: 'UPPER_CASE' }],
     },
     {
-      options: [
-        {
-          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
-            style: 'camelCase',
-            requiredPrefixes: ['is', 'has'],
-          },
-          'FieldDefinition[gqlType.gqlType.name.value=Secret]': {
-            requiredPrefixes: ['SUPER_SECRET_'],
-          },
-          'FieldDefinition[gqlType.name.value=Snake]': {
-            style: 'snake_case',
-            requiredPrefixes: ['hiss'],
-          },
-        },
-      ],
       code: /* GraphQL */ `
         scalar Secret
 
@@ -189,8 +174,31 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
           hiss_snake: Snake
         }
       `,
+      options: [
+        {
+          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+            style: 'camelCase',
+            requiredPrefixes: ['is', 'has'],
+          },
+          'FieldDefinition[gqlType.gqlType.name.value=Secret]': {
+            requiredPrefixes: ['SUPER_SECRET_'],
+          },
+          'FieldDefinition[gqlType.name.value=Snake]': {
+            style: 'snake_case',
+            requiredPrefixes: ['hiss_'],
+          },
+        },
+      ],
     },
     {
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeatureEnabled: Boolean!
+          userIpAddress: IpAddress!
+        }
+      `,
       options: [
         {
           'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
@@ -202,14 +210,6 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
           },
         },
       ],
-      code: /* GraphQL */ `
-        scalar IpAddress
-
-        type Test {
-          specialFeatureEnabled: Boolean!
-          userIpAddress: IpAddress!
-        }
-      `,
     },
   ],
   invalid: [
@@ -457,6 +457,19 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
     },
     {
       name: 'should error when selected type names do not match require prefixes',
+      code: /* GraphQL */ `
+        scalar Secret
+
+        interface Snake {
+          value: String!
+        }
+
+        type Test {
+          enabled: Boolean!
+          secret: Secret!
+          snake: Snake
+        }
+      `,
       options: [
         {
           'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
@@ -472,27 +485,18 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
           },
         },
       ],
-      code: /* GraphQL */ `
-        scalar Secret
-
-        interface Snake {
-          value: String!
-        }
-
-        type Test {
-          enabled: Boolean!
-          secret: Secret!
-          snake: Snake
-        }
-      `,
-      errors: [
-        { message: 'Field "enabled" should have one of the following prefixes: is, or has' },
-        { message: 'Field "secret" should have one of the following prefixes: SUPER_SECRET_' },
-        { message: 'Field "snake" should have one of the following prefixes: hiss' },
-      ],
+      errors: 3,
     },
     {
       name: 'should error when selected type names do not match require suffixes',
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeature: Boolean!
+          user: IpAddress!
+        }
+      `,
       options: [
         {
           'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
@@ -504,21 +508,7 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
           },
         },
       ],
-      code: /* GraphQL */ `
-        scalar IpAddress
-
-        type Test {
-          specialFeature: Boolean!
-          user: IpAddress!
-        }
-      `,
-      errors: [
-        {
-          message:
-            'Field "specialFeature" should have one of the following suffixes: Enabled, or Disabled',
-        },
-        { message: 'Field "user" should have one of the following suffixes: IpAddress' },
-      ],
+      errors: 2,
     },
   ],
 });

--- a/packages/plugin/tests/naming-convention.spec.ts
+++ b/packages/plugin/tests/naming-convention.spec.ts
@@ -190,6 +190,27 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
         }
       `,
     },
+    {
+      options: [
+        {
+          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+            style: 'camelCase',
+            requiredSuffixes: ['Enabled', 'Disabled'],
+          },
+          'FieldDefinition[gqlType.gqlType.name.value=IpAddress]': {
+            requiredSuffixes: ['IpAddress'],
+          },
+        },
+      ],
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeatureEnabled: Boolean!
+          userIpAddress: IpAddress!
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -435,7 +456,7 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
       ],
     },
     {
-      name: 'should error when selected types do not match require prefixes',
+      name: 'should error when selected type names do not match require prefixes',
       options: [
         {
           'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
@@ -468,6 +489,35 @@ ruleTester.runGraphQLTests<RuleOptions>('naming-convention', rule, {
         { message: 'Field "enabled" should have one of the following prefixes: is, or has' },
         { message: 'Field "secret" should have one of the following prefixes: SUPER_SECRET_' },
         { message: 'Field "snake" should have one of the following prefixes: hiss' },
+      ],
+    },
+    {
+      name: 'should error when selected type names do not match require suffixes',
+      options: [
+        {
+          'FieldDefinition[gqlType.gqlType.name.value=Boolean]': {
+            style: 'camelCase',
+            requiredSuffixes: ['Enabled', 'Disabled'],
+          },
+          'FieldDefinition[gqlType.gqlType.name.value=IpAddress]': {
+            requiredSuffixes: ['IpAddress'],
+          },
+        },
+      ],
+      code: /* GraphQL */ `
+        scalar IpAddress
+
+        type Test {
+          specialFeature: Boolean!
+          user: IpAddress!
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Field "specialFeature" should have one of the following suffixes: Enabled, or Disabled',
+        },
+        { message: 'Field "user" should have one of the following suffixes: IpAddress' },
       ],
     },
   ],


### PR DESCRIPTION
## Description

https://github.com/B2o5T/graphql-eslint/issues/1521

This adds two new configuration options to `naming-convention`:

* `requiredPrefixes` – if supplied, the selected field name must have one of the supplied prefixes
* `requiredSuffixes` – if supplied, the selected field name must have one of the supplied suffixes

Fixes #[1521](https://github.com/B2o5T/graphql-eslint/issues/1521)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Added relevant tests in `naming-convention.spec.ts`

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
