### PR TITLE
Fix broken suggestion URLs in rules

### DIFF
--- a/.changeset/spicy-books-tell.md
+++ b/.changeset/spicy-books-tell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-eslint/eslint-plugin': patch
+---
+
+broken rule url for `require-import-fragment` and `require-nullable-result-in-root`

--- a/packages/plugin/src/rules/require-import-fragment.ts
+++ b/packages/plugin/src/rules/require-import-fragment.ts
@@ -13,7 +13,7 @@ export const rule: GraphQLESLintRule = {
     docs: {
       category: 'Operations',
       description: 'Require fragments to be imported via an import expression.',
-      url: `https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/${RULE_ID}.md`,
+      url: `https://the-guild.dev/graphql/eslint/rules/${RULE_ID}`,
       examples: [
         {
           title: 'Incorrect',

--- a/packages/plugin/src/rules/require-nullable-result-in-root.ts
+++ b/packages/plugin/src/rules/require-nullable-result-in-root.ts
@@ -12,7 +12,7 @@ export const rule: GraphQLESLintRule = {
     docs: {
       category: 'Schema',
       description: 'Require nullable fields in root types.',
-      url: `https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/${RULE_ID}.md`,
+      url: `https://the-guild.dev/graphql/eslint/rules/${RULE_ID}`,
       requiresSchema: true,
       examples: [
         {

--- a/scripts/create-rule.ts
+++ b/scripts/create-rule.ts
@@ -67,7 +67,7 @@ export const rule: GraphQLESLintRule = {
     docs: {
       category: '${category}',
       description: '${description}',
-      url: \`https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/\${RULE_ID}.md\`,
+      url: \`https://the-guild.dev/graphql/eslint/rules/\${RULE_ID}\`,
       examples: [
         {
           title: 'Incorrect',


### PR DESCRIPTION
## Description

This fixes the two rule suggestions, which result in a 404 when you try to click the links in vscode.

- require-import-fragment
- require-nullable-result-in-root

Fixes #1715 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

**Test Environment**:

- OS: MaOS / vscode
- `@graphql-eslint/...`:
- NodeJS: v19.9.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

